### PR TITLE
ci: workflow correctness — gate promote, ref-cancel, fail-fast: false, drop --privileged

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -18,7 +18,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel topic-branch runs freely (fast feedback on iterated pushes) but
+  # NEVER cancel a main run mid-`promote` — half-published Docker Hub tags
+  # are worse than the cost of letting two main runs finish serially.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -147,6 +150,8 @@ jobs:
   # re-installed per chain on purpose — the symmetric, easy-to-follow graph matters more than dedup
   # (CI is free on open source).
   # Matrix `os` is currently [ubuntu]; adding alpine = extend the list (+ os-specific dirs).
+  # Every build-* job sets `fail-fast: false` so an alpine failure does not cancel an in-flight
+  # ubuntu push (or vice versa), which would leave the downstream chain with a missing parent.
   # ----------------------------------------------------------------------------
 
   build-gha-tools:
@@ -156,6 +161,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -177,6 +183,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -199,6 +206,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -219,6 +227,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -241,6 +250,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -262,6 +272,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -284,6 +295,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -304,6 +316,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -327,6 +340,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -348,6 +362,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -370,6 +385,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -391,6 +407,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -415,6 +432,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -436,6 +454,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
     steps:
@@ -625,7 +644,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
-        --privileged
         --env "HOME=/home/runner"
     steps:
       - run: node --version
@@ -650,7 +668,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
-        --privileged
         --env "HOME=/home/runner"
     steps:
       - run: node --version   # inherited from the node layer
@@ -674,7 +691,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
-        --privileged
         --env "HOME=/home/runner"
     steps:
       - run: pnpm --version
@@ -718,7 +734,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: >-
-        --privileged
         --env "HOME=/home/runner"
     steps:
       - uses: actions/checkout@v4
@@ -900,12 +915,20 @@ jobs:
   # ----------------------------------------------------------------------------
 
   promote:
+    # Publish consumer tags to Docker Hub ONLY on main, ONLY after all tests pass.
+    # The test-gate is satisfied by `needs:` enumerating every `test-*` job below;
+    # the branch-gate (this `if:`) blocks topic-branch / PR / Renovate pushes from
+    # publishing tags. Matches the idiom in playwright-alpine-browsers.yml.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [github-context, versions, test-gha-tools-usage, test-dood-dind-usage, test-dood-dind-effects, test-dood-dind-act, test-node-usage, test-pnpm-usage, test-pnpm-gyp-usage, test-playwright-usage]
     permissions:
       contents: read
       packages: write
     strategy:
+      # One transient Docker Hub 502 should not cancel the other 25 cells mid-
+      # `imagetools create` — that leaves consumer tags partially advanced.
+      fail-fast: false
       matrix:
         os: [ubuntu, alpine]
         image: [gha-tools, dood, dind, dood-node, dind-node, dood-pnpm, dind-pnpm, dood-pnpm-gyp, dind-pnpm-gyp, dood-playwright, dind-playwright, dood-playwright-gyp, dind-playwright-gyp]


### PR DESCRIPTION
## Summary

Addresses four findings from the code review (`/home/jean/.claude/plans/partitioned-wandering-music.md`):

- **#1** — `promote` now gates on `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`. Closes the topic-branch leak (live evidence: `jclaveau/ubuntu-dood` carried `renovate-*` and `playwright-alpine-browsers-*` sha tags from non-main pushes). Matches the idiom in `playwright-alpine-browsers.yml`.

  **Side-effect (intended):** finding #4 (`pr-N` tag pollution) is closed by the same change — PRs no longer trigger promote, no metadata-action invocation, no `pr-N` tag publishing.

- **#2** — `concurrency.cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`. Topic-branch runs still cancel-in-progress (fast iteration); a main run never gets SIGKILL'd mid-`imagetools create` (half-published Docker Hub state is worse than serial main runs).

- **#3** — `fail-fast: false` on every `build-*` matrix and on `promote`. An alpine failure no longer cancels in-flight ubuntu pushes; one transient Docker Hub 502 no longer cancels 25 sibling `imagetools` cells. (This very PR's CI flakiness on PR #22's `build-dind (ubuntu)` step demonstrates the exact failure mode this fixes — a single transient `registry-1.docker.io context deadline exceeded` should not cascade.)

- **#9** — Drop `--privileged` from `test-node-usage`, `test-pnpm-usage`, `test-pnpm-gyp-usage`, `test-playwright-usage`. These run language tools only (no nested docker); `--privileged` was over-broad. `test-dood-dind-{usage,effects,act}` keep it (genuinely need nested docker / the inner daemon).

## Test plan

- [ ] CI green across all `build-*` and `test-*` jobs (proves no regression from `--privileged` removal on language-tool jobs)
- [ ] `promote` does NOT run on this PR (it's a PR event, not a push to main)
- [ ] After merge: confirm `promote` runs on the next main push and publishes consumer tags as expected

## Out of scope

- Cleaning up the historical `renovate-*` / `playwright-alpine-browsers-*` topic-branch tags already on Docker Hub — a separate housekeeping pass.
- Removing the now-misleading `type=ref,event=pr` line in the metadata-action block: dead code after this change, but a follow-up cleanup (not load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)