### PR TITLE
feat: gha-tools — set WORKDIR/RUNNER_TOOL_CACHE; drop broken CMD; add effects test

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -536,6 +536,51 @@ jobs:
           check la 'ls -A'
           check l  'ls -CF'
 
+  test-gha-tools-effects:
+    # Asserts the image's RUNTIME defaults (WORKDIR, USER, env, dir perms) that GHA's
+    # `container:` overrides hide from `test-gha-tools-usage` — i.e. what consumers see
+    # under act, local `docker run`, dood --bind, etc. Mirrors the usage/effects split
+    # already used for dood/dind.
+    runs-on: ubuntu-latest
+    needs: [github-context, build-gha-tools]
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, alpine]
+    env:
+      IMG: ghcr.io/jclaveau/${{ matrix.os }}-gha-tools:${{ needs.github-context.outputs.build_tag }}
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Default WORKDIR mimics hosted-runner home
+        run: |
+          cwd=$(docker run --rm "$IMG" pwd)
+          echo "pwd=$cwd"
+          test "$cwd" = "/home/runner"
+      - name: Default USER is runner (uid 1001)
+        run: |
+          uid=$(docker run --rm "$IMG" id -u)
+          echo "uid=$uid"
+          test "$uid" = "1001"
+      - name: RUNNER_TOOL_CACHE env baked in
+        run: |
+          v=$(docker run --rm "$IMG" sh -c 'echo "$RUNNER_TOOL_CACHE"')
+          echo "RUNNER_TOOL_CACHE=$v"
+          test "$v" = "/opt/hostedtoolcache"
+      - name: $RUNNER_TOOL_CACHE writable as default user
+        run: docker run --rm "$IMG" sh -c 'touch "$RUNNER_TOOL_CACHE/probe" && echo OK'
+      - name: $RUNNER_TOOL_CACHE writable under host-UID override (dood bind recipe)
+        # An arbitrary host UID writes via the runner supplementary group + sgid 2775.
+        run: docker run --rm --user 5000:5000 --group-add 1001 "$IMG" sh -c 'touch "$RUNNER_TOOL_CACHE/probe-5000" && echo OK'
+      - name: /home/runner writable under host-UID override
+        # WORKDIR is /home/runner; chmod 0775 + runner group must keep it writable for UID 5000.
+        # Load-bearing for the dood `--bind --user $HOST_UID --group-add 1001` recipe.
+        run: docker run --rm --user 5000:5000 --group-add 1001 "$IMG" sh -c 'touch ./probe && echo OK'
+
   test-dood-dind-usage:
     runs-on: ubuntu-latest
     needs: [github-context, build-dood, build-dind]
@@ -980,7 +1025,7 @@ jobs:
     # publishing tags. Matches the idiom in playwright-alpine-browsers.yml.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [github-context, versions, test-gha-tools-usage, test-dood-dind-usage, test-dood-dind-effects, test-dood-dind-act, test-node-usage, test-pnpm-usage, test-pnpm-gyp-usage, test-playwright-usage]
+    needs: [github-context, versions, test-gha-tools-usage, test-gha-tools-effects, test-dood-dind-usage, test-dood-dind-effects, test-dood-dind-act, test-node-usage, test-pnpm-usage, test-pnpm-gyp-usage, test-playwright-usage]
     permissions:
       contents: read
       packages: write

--- a/alpine-gha-tools/Dockerfile
+++ b/alpine-gha-tools/Dockerfile
@@ -117,7 +117,12 @@ SCRIPT
 chmod 0755 /usr/local/bin/nss-wrapper-setup
 EOF
 
-USER runner
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 
-# Github overrides workdir and entrypoint during `docker create`; this CMD is the only way to set PWD.
-CMD ["cd", "$PWD"]
+# Match the hosted runner's default cwd. GHA's `container:` overrides via
+# `docker exec -w $GITHUB_WORKSPACE`, and act --bind sets its own workdir
+# — both ignore this. Only affects `docker run` use (interactive sanity
+# checks, dood bind-mode when the consumer hasn't passed `-w` explicitly).
+WORKDIR /home/runner
+USER runner
+# Default CMD inherits from the base image (sh on alpine).

--- a/ubuntu-gha-tools/Dockerfile
+++ b/ubuntu-gha-tools/Dockerfile
@@ -108,7 +108,12 @@ SCRIPT
 chmod 0755 /usr/local/bin/nss-wrapper-setup
 EOF
 
-USER runner
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
 
-# Github overrides workdir and entrypoint during `docker create`; this CMD is the only way to set PWD.
-CMD ["cd", "$PWD"]
+# Match the hosted runner's default cwd. GHA's `container:` overrides via
+# `docker exec -w $GITHUB_WORKSPACE`, and act --bind sets its own workdir
+# — both ignore this. Only affects `docker run` use (interactive sanity
+# checks, dood bind-mode when the consumer hasn't passed `-w` explicitly).
+WORKDIR /home/runner
+USER runner
+# Default CMD inherits from the base image (bash on ubuntu).


### PR DESCRIPTION
## Summary

Addresses **Finding #6** from the code review (`/home/jean/.claude/plans/partitioned-wandering-music.md`). The originally-planned **Finding #10** (frozen-toolkit + `-sudoer` flavor) is **deferred to a follow-up PR** — the simple "strip sudoers from gha-tools" approach broke every downstream Dockerfile that uses `sudo` at build time (e.g. `docker/Dockerfile.alpine` does `sudo apk add` etc.). The correct design is a "strip-at-end overlay" — the build chain keeps sudoers throughout, and a final hardening overlay strips it after promote. That redesign deserves its own PR.

## What this PR does (Finding #6 only)

- `ubuntu-gha-tools/Dockerfile`, `alpine-gha-tools/Dockerfile`: replace the live-broken `CMD ["cd", "$PWD"]` (exec-form JSON, `$PWD` not expanded, `cd` is a builtin → ENOENT — confirmed via live `docker run`) with:
  - `ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache` so the env mirrors the hosted runner outside GHA's container-job harness too
  - `WORKDIR /home/runner` so `docker run -it` lands in the runner user's home (GHA overrides via `docker exec -w $GITHUB_WORKSPACE`; act --bind sets its own workdir; this only affects interactive use)
  - Default CMD inherits from the base image (bash on ubuntu, sh on alpine)

- `test-and-publish.yml`: new `test-gha-tools-effects` job mirroring the usage/effects split already used for dood/dind. Runs on `ubuntu-latest` (not in a container, since `container:` overrides WORKDIR + USER + runs as root); spawns `docker run` against the candidate image to observe runtime defaults:
  - `pwd = /home/runner` (catches WORKDIR removal)
  - `id -u = 1001` (catches USER override)
  - `$RUNNER_TOOL_CACHE = /opt/hostedtoolcache` (catches ENV removal)
  - `$RUNNER_TOOL_CACHE` writable as default user (chmod 2775 regression)
  - `$RUNNER_TOOL_CACHE` writable under `--user 5000 --group-add 1001` (sgid bit / group ownership regression)
  - `/home/runner` writable under the same host-UID override (chmod 0775 regression — load-bearing per project memory `project_act_bind_host_uid_recipe.md`)

- `promote.needs`: `test-gha-tools-effects` added to the gate.

## Deferred to a follow-up PR

**Finding #10 (frozen-toolkit + `-sudoer` flavor)**. The correct design is to keep sudoers throughout the build chain and add a final overlay that strips them — published as `<image>:latest` (hardened default) with `<image>-sudoer:latest` being the unmodified build-chain image. The "strip-at-start" approach attempted in this branch's earlier (now force-pushed-away) commits broke every downstream `sudo apt-get install` / `sudo apk add` at build time.

## Test plan

- [ ] CI green across the existing `build-*` and `test-*` jobs (no regression from the WORKDIR/ENV changes)
- [ ] `test-gha-tools-effects` runs and all 6 assertions pass on both `ubuntu` and `alpine` cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)
