### PR TITLE
ci: register prebuilt-base workflow on main

### DIFF
--- a/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
+++ b/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
@@ -1,0 +1,87 @@
+name: Playwright Alpine Browsers — Prebuilt Base (one-shot ~3h FF compile)
+
+# Producer workflow for the prebuilt-base image: a heavy, ONCE-per-upstream-FF-
+# revision build that ships the full /work/firefox-src tree + populated obj/
+# dir. The iteration workflow (playwright-alpine-browsers.yml with
+# use_prebuilt=true) consumes it as FROM, turning ~3h cold builds into ~5 min
+# incremental rebuilds.
+#
+# Manual dispatch only — at ~3h per run this is too expensive to fire on push.
+
+on:
+  # Label-based pull_request trigger registers the workflow with GHA so
+  # workflow_dispatch becomes usable. Add label `build-prebuilt-base` to the
+  # PR to trigger; the if: on the first job ignores any other label.
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+# Own concurrency group so a prebuilt-base run never collides with the regular
+# iteration workflow. Never cancel an in-flight 3h build.
+concurrency:
+  group: playwright-alpine-browsers-prebuilt-base-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    # Only fire on workflow_dispatch OR when the PR gets labeled
+    # `build-prebuilt-base`. Any other event/label is ignored.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'build-prebuilt-base')
+    runs-on: ubuntu-latest
+    timeout-minutes: 300   # 5h ceiling — one-shot cold compile is ~3h.
+    outputs:
+      pw_version: ${{ steps.pins.outputs.pw_version }}
+      firefox_revision: ${{ steps.pins.outputs.firefox_revision }}
+      firefox_version: ${{ steps.pins.outputs.firefox_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Read versions.env into both step env (for shell expansions) and job
+      # outputs (for downstream jobs / publish tags).
+      - id: pins
+        run: |
+          set -a; . playwright/alpine-browsers/versions.env; set +a
+          echo "pw_version=$PW_VERSION" >> "$GITHUB_OUTPUT"
+          # Resolve PW's pinned firefox revision + version from the matching
+          # playwright-core npm package's browsers.json. Single source of truth.
+          BROWSERS_JSON=$(curl -fsSL "https://unpkg.com/playwright-core@${PW_VERSION}/browsers.json")
+          REV=$(jq -r '.browsers[] | select(.name=="firefox") | .revision' <<<"$BROWSERS_JSON")
+          VER=$(jq -r '.browsers[] | select(.name=="firefox") | .browserVersion' <<<"$BROWSERS_JSON")
+          echo "firefox_revision=$REV" >> "$GITHUB_OUTPUT"
+          echo "firefox_version=$VER" >> "$GITHUB_OUTPUT"
+          echo "PW v${PW_VERSION} → firefox revision=${REV} browserVersion=${VER}"
+
+      - name: Free up runner disk (FF source + obj dir is ~15 GB)
+        run: |
+          # Standard GHA hosted-runner cleanup recipe. Frees ~30 GB.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push prebuilt-base image
+        uses: docker/build-push-action@v5
+        with:
+          context: playwright/alpine-browsers
+          file: playwright/alpine-browsers/Dockerfile.prebuilt-base
+          push: true
+          tags: |
+            ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}
+            ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-latest
+          # Dedicated registry cache for the prebuilt-base lineage — separate
+          # from the iteration workflow's :buildcache to avoid cross-contamination.
+          cache-from: type=registry,ref=ghcr.io/jclaveau/playwright-alpine-browsers:buildcache-prebuilt
+          cache-to: type=registry,ref=ghcr.io/jclaveau/playwright-alpine-browsers:buildcache-prebuilt,mode=max


### PR DESCRIPTION
## Why

The prebuilt-base workflow needs to exist on the default branch for `gh workflow run --ref <pr-branch>` to be permitted by GHA. Without it, dispatching the workflow from PR #17 returns 404 even though the file is committed on that branch.

## What

Adds **only** `.github/workflows/playwright-alpine-browsers-prebuilt-base.yml`. No auto-fire triggers — only `pull_request: types: [labeled]` (with an `if:` filter on the specific label) and `workflow_dispatch`. Landing this on main is a no-op until someone explicitly dispatches it or adds the `build-prebuilt-base` label to a PR.

## Out of scope

The actual prebuilt-base implementation (Dockerfile.prebuilt-base, apply-and-build-iter.sh, Dockerfile.iter, the `use_prebuilt` input wiring on the main musl workflow) lives on PR #17 and will land via that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)