### PR TITLE
feat(on-demand): multi-select os / image / flavor (empty = build all)

### DIFF
--- a/.github/ISSUE_TEMPLATE/build-request.yml
+++ b/.github/ISSUE_TEMPLATE/build-request.yml
@@ -19,22 +19,23 @@ body:
     id: os
     attributes:
       label: OS family
+      description: 'Pick one or more. **Leave empty to build both** (~2x wall-clock).'
+      multiple: true
       options:
         - ubuntu
         - alpine
-    validations: { required: true }
   - type: input
     id: os_version
     attributes:
       label: OS version
-      description: 'e.g. `22.04` for Ubuntu, `3.20` for Alpine.'
+      description: 'e.g. `22.04` for Ubuntu, `3.20` for Alpine. Leave empty to use the default of each picked OS (24.04 / 3.21).'
       placeholder: '22.04'
-    validations: { required: true }
   - type: dropdown
     id: image
     attributes:
-      label: Image variant
-      description: '`gha-tools` is the OS-only base. The full list mirrors the matrix in `test-and-publish.yml`.'
+      label: Image variant(s)
+      description: 'Pick one or more. **Leave empty to build all 13.** `gha-tools` is the OS-only base; the full list mirrors the matrix in `test-and-publish.yml`. Each picked variant becomes one cell in the build matrix.'
+      multiple: true
       options:
         - gha-tools
         - dood
@@ -49,17 +50,15 @@ body:
         - dind-playwright
         - dood-playwright-gyp
         - dind-playwright-gyp
-    validations: { required: true }
   - type: dropdown
     id: flavor
     attributes:
       label: Flavor
-      description: '`hardened` is the consumer default (no broad sudo). `sudoer` is the build-chain image (runner NOPASSWD intact); use only if you specifically need it.'
+      description: 'Pick one or more. **Leave empty to build both.** `hardened` is the consumer default (no broad sudo); `sudoer` is the build-chain image (runner NOPASSWD intact).'
+      multiple: true
       options:
         - hardened
         - sudoer
-      default: 0
-    validations: { required: true }
   - type: input
     id: node_version
     attributes:

--- a/.github/workflows/on-demand-build.yml
+++ b/.github/workflows/on-demand-build.yml
@@ -30,17 +30,17 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'build-request')
     runs-on: ubuntu-latest
     outputs:
-      os:             ${{ steps.parse.outputs.os }}
-      os_version:     ${{ steps.parse.outputs.os_version }}
-      image:          ${{ steps.parse.outputs.image }}
-      flavor:         ${{ steps.parse.outputs.flavor }}        # '' (hardened) or '-sudoer'
-      node_version:   ${{ steps.parse.outputs.node_version }}
-      pnpm_version:   ${{ steps.parse.outputs.pnpm_version }}
-      pw_version:     ${{ steps.parse.outputs.pw_version }}
-      predicted_tag:  ${{ steps.predict.outputs.tag }}
-      docker_repo:    ${{ steps.predict.outputs.repo }}
-      quota_ok:       ${{ steps.quota.outputs.ok }}
-      already_exists: ${{ steps.existing.outputs.exists }}
+      # All three axes accept CSV / empty. The downstream test-and-publish workflow
+      # parses them into matrix arrays; an empty value fans out to every default
+      # entry on that axis (full chain rebuild at the requested version pins).
+      os:           ${{ steps.parse.outputs.os }}
+      os_version:   ${{ steps.parse.outputs.os_version }}
+      image:        ${{ steps.parse.outputs.image }}
+      flavor:       ${{ steps.parse.outputs.flavor }}
+      node_version: ${{ steps.parse.outputs.node_version }}
+      pnpm_version: ${{ steps.parse.outputs.pnpm_version }}
+      pw_version:   ${{ steps.parse.outputs.pw_version }}
+      quota_ok:     ${{ steps.quota.outputs.ok }}
     steps:
       - id: ensure-labels
         # `gh issue edit --add-label` errors if the label doesn't exist in the
@@ -84,18 +84,18 @@ jobs:
             [ "$v" = "_No response_" ] && v=""
             printf '%s' "$v"
           }
-          OS=$(extract "OS family")
-          OS_VERSION=$(extract "OS version")
-          IMAGE=$(extract "Image variant")
-          FLAVOR_LABEL=$(extract "Flavor")
-          NODE=$(opt   "Node version (optional)")
-          PNPM=$(opt   "pnpm version (optional)")
-          PW=$(opt     "Playwright version (optional)")
-          case "$FLAVOR_LABEL" in
-            hardened) FLAVOR="" ;;
-            sudoer)   FLAVOR="-sudoer" ;;
-            *) echo "::error::Unknown flavor: $FLAVOR_LABEL"; exit 1 ;;
-          esac
+          # Every axis is optional in the form (empty = build all). For multi-select
+          # fields, the form body renders selected values as a comma-separated list
+          # on a single line — exactly the CSV format test-and-publish expects, so
+          # parse just passes the value through verbatim. Friendly flavor names
+          # (hardened/sudoer) map to matrix values inside the matrices step.
+          OS=$(opt          "OS family")
+          OS_VERSION=$(opt  "OS version")
+          IMAGE=$(opt       "Image variant(s)")
+          FLAVOR=$(opt      "Flavor")
+          NODE=$(opt        "Node version (optional)")
+          PNPM=$(opt        "pnpm version (optional)")
+          PW=$(opt          "Playwright version (optional)")
           {
             echo "os=$OS"
             echo "os_version=$OS_VERSION"
@@ -105,48 +105,7 @@ jobs:
             echo "pnpm_version=$PNPM"
             echo "pw_version=$PW"
           } >> "$GITHUB_OUTPUT"
-          echo "Parsed: os=$OS os_version=$OS_VERSION image=$IMAGE flavor='$FLAVOR' node='$NODE' pnpm='$PNPM' pw='$PW'"
-
-      - id: predict
-        # Compose the would-be pinned tag from the requested inputs (the actual
-        # tag is composed by `promote` from `docker run` against the built image,
-        # so for unusual minor pinnings this prediction may differ — used only
-        # for the `existing` precheck and the success comment, not for the
-        # publish itself).
-        env:
-          OS:           ${{ steps.parse.outputs.os }}
-          OS_VERSION:   ${{ steps.parse.outputs.os_version }}
-          IMAGE:        ${{ steps.parse.outputs.image }}
-          FLAVOR:       ${{ steps.parse.outputs.flavor }}
-          NODE_VERSION: ${{ steps.parse.outputs.node_version }}
-          PNPM_VERSION: ${{ steps.parse.outputs.pnpm_version }}
-          PW_VERSION:   ${{ steps.parse.outputs.pw_version }}
-        run: |
-          set -euo pipefail
-          # Match the truncation `versions` does: node major.minor from `node -v`,
-          # pnpm major.minor from `pnpm -v`, playwright major.minor from `--version`.
-          # Strip third+ segments from user input so the prediction matches.
-          majmin() { echo "$1" | cut -d. -f1,2; }
-          OS_TAG="${OS}${OS_VERSION}"
-          case "$IMAGE" in
-            gha-tools|dood|dind)
-              TAG="${OS_TAG}" ;;
-            dood-node|dind-node)
-              TAG="${OS_TAG}-node$(majmin "$NODE_VERSION")" ;;
-            dood-pnpm|dind-pnpm)
-              TAG="${OS_TAG}-node$(majmin "$NODE_VERSION")-pnpm$(majmin "$PNPM_VERSION")" ;;
-            dood-pnpm-gyp|dind-pnpm-gyp)
-              TAG="${OS_TAG}-node$(majmin "$NODE_VERSION")-pnpm$(majmin "$PNPM_VERSION")-gyp" ;;
-            dood-playwright|dind-playwright)
-              TAG="${OS_TAG}-node$(majmin "$NODE_VERSION")-pnpm$(majmin "$PNPM_VERSION")-pw$(majmin "$PW_VERSION")" ;;
-            dood-playwright-gyp|dind-playwright-gyp)
-              TAG="${OS_TAG}-node$(majmin "$NODE_VERSION")-pnpm$(majmin "$PNPM_VERSION")-pw$(majmin "$PW_VERSION")-gyp" ;;
-          esac
-          [ "$FLAVOR" = "-sudoer" ] && TAG="${TAG}-sudoer"
-          REPO="jclaveau/${OS}-${IMAGE}${FLAVOR}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
-          echo "Predicted: ${REPO}:${TAG}"
+          echo "Parsed: os='$OS' os_version='$OS_VERSION' image='$IMAGE' flavor='$FLAVOR' node='$NODE' pnpm='$PNPM' pw='$PW'"
 
       - id: quota
         # 3 builds / 24h / requester. Counts any build-request-labelled issue
@@ -175,44 +134,25 @@ jobs:
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - id: existing
-        # Best-effort precheck — if the predicted tag is already on Docker Hub,
-        # skip the build (push would be a no-op anyway). Anonymous manifest
-        # inspect; rate limited at 100/6h, well above the 3/24h quota.
-        if: steps.quota.outputs.ok == 'true'
-        env:
-          REPO: ${{ steps.predict.outputs.repo }}
-          TAG: ${{ steps.predict.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if docker manifest inspect "${REPO}:${TAG}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Predicted tag already on Docker Hub — skipping build"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+      # An existing-tag precheck used to live here, predicting the pinned tag from
+      # the inputs and skipping the build if it was already on Docker Hub. With
+      # multi-select axes the prediction would have to fan out across every
+      # combination, so the precheck was dropped — Docker Hub push of an unchanged
+      # digest is a no-op anyway, and the cost is one rebuild for the rare case
+      # of a fully-redundant request.
 
       - id: notify-start
-        if: steps.quota.outputs.ok == 'true' && steps.existing.outputs.exists != 'true'
+        if: steps.quota.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           gh issue comment "${{ github.event.issue.number }}" --body \
-            ":hammer_and_wrench: Build started: ${{ steps.predict.outputs.repo }}:${{ steps.predict.outputs.tag }}. Wall-clock ~5-30 min depending on variant. Progress: $RUN_URL"
-
-      - id: skip-existing-notify
-        if: steps.quota.outputs.ok == 'true' && steps.existing.outputs.exists == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue comment "${{ github.event.issue.number }}" --body \
-            ":white_check_mark: That combination is already published as \`${{ steps.predict.outputs.repo }}:${{ steps.predict.outputs.tag }}\`. Pull it directly — no rebuild needed."
-          gh issue close "${{ github.event.issue.number }}"
+            ":hammer_and_wrench: Build started. Wall-clock ~5-30 min depending on variant + matrix size. Progress: $RUN_URL"
 
   build:
     needs: prepare
-    if: needs.prepare.outputs.quota_ok == 'true' && needs.prepare.outputs.already_exists != 'true'
+    if: needs.prepare.outputs.quota_ok == 'true'
     uses: ./.github/workflows/test-and-publish.yml
     secrets: inherit
     with:
@@ -227,9 +167,8 @@ jobs:
 
   comment-close:
     needs: [prepare, build]
-    # Run only after the build attempt, ONLY if quota passed (skip-existing
-    # closes the issue itself). `always()` so failures still get a comment.
-    if: always() && needs.prepare.outputs.quota_ok == 'true' && needs.prepare.outputs.already_exists != 'true'
+    # Run after the build attempt. `always()` so failures still get a comment.
+    if: always() && needs.prepare.outputs.quota_ok == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Comment success + close
@@ -238,7 +177,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh issue comment "${{ github.event.issue.number }}" --body \
-            ":white_check_mark: Build complete. Published: \`${{ needs.prepare.outputs.docker_repo }}:${{ needs.prepare.outputs.predicted_tag }}\`. (If you pinned other minors, the actual tag may differ — check https://hub.docker.com/r/${{ needs.prepare.outputs.docker_repo }}/tags.)"
+            ":white_check_mark: Build complete. New pinned tag(s) live under https://hub.docker.com/u/jclaveau — search by image variant + version components matching what you requested."
           gh issue close "${{ github.event.issue.number }}"
       - name: Comment failure + label
         if: needs.build.result != 'success'

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -18,12 +18,12 @@ on:
       node_version:    { type: string,  default: '' }   # e.g. '20.18.0'
       pnpm_version:    { type: string,  default: '' }   # e.g. '9.15.3'
       pw_version:      { type: string,  default: '' }   # e.g. '1.50.1'
-      only_os:         { type: string,  default: '' }   # 'ubuntu' | 'alpine' | '' (both)
-      only_image:      { type: string,  default: '' }   # e.g. 'dood-playwright' | '' (all)
-      # Flavor naming follows the matrix axis at the `promote` job: '' = hardened (consumer
-      # default), '-sudoer' = the un-hardened build-chain image. 'all' means no filter — used
-      # by the push/PR path (default) so both flavors are promoted as today.
-      only_flavor:     { type: string,  default: 'all' }   # 'all' | '' (hardened) | '-sudoer'
+      # All three `only_*` axes use the same convention: comma-separated friendly names,
+      # empty = no filter (every default-matrix entry runs, byte-identical to today).
+      # Whitespace around commas is tolerated.
+      only_os:         { type: string,  default: '' }   # 'ubuntu' | 'alpine' (CSV) | '' (both)
+      only_image:      { type: string,  default: '' }   # CSV of variants, e.g. 'dood-playwright,dind-playwright' | '' (all 13)
+      only_flavor:     { type: string,  default: '' }   # 'hardened' | 'sudoer' (CSV) | '' (both)
       publish_latest:  { type: boolean, default: true }
   # schedule:
   #   # Run weekly to get security updates
@@ -88,24 +88,58 @@ jobs:
           ONLY_FLAVOR: ${{ inputs.only_flavor }}
         run: |
           set -euo pipefail
-          # OS axis
+
+          # Comma-separated → JSON array. Trims whitespace per entry, drops empties
+          # (so 'a, b' and 'a,b' both work). Optional second arg maps friendly names
+          # to matrix values via a `friendly=value` lookup table (used by flavor).
+          # Unknown entries error out so a typo in an issue body fails loudly here
+          # rather than silently expanding to a never-matching matrix cell.
+          csv_to_json() {
+            local csv="$1" map="${2:-}" json='[' sep=''
+            IFS=',' read -ra parts <<< "$csv"
+            local raw trimmed mapped found pair k v
+            for raw in "${parts[@]}"; do
+              trimmed=$(echo "$raw" | xargs)
+              [ -z "$trimmed" ] && continue
+              if [ -n "$map" ]; then
+                found=0; mapped=''
+                for pair in $map; do
+                  k="${pair%%=*}" v="${pair#*=}"
+                  if [ "$k" = "$trimmed" ]; then mapped="$v"; found=1; break; fi
+                done
+                if [ "$found" = 0 ]; then
+                  echo "::error::Unknown value '$trimmed' (allowed: $(echo "$map" | sed 's/=[^ ]*//g; s/ /,/g'))"
+                  exit 1
+                fi
+                trimmed="$mapped"
+              fi
+              json+="${sep}\"${trimmed}\""
+              sep=','
+            done
+            json+=']'
+            echo "$json"
+          }
+
+          # OS axis (every job with matrix.os).
           if [ -n "$ONLY_OS" ]; then
-            echo "os_matrix=[\"$ONLY_OS\"]" >> "$GITHUB_OUTPUT"
+            echo "os_matrix=$(csv_to_json "$ONLY_OS")" >> "$GITHUB_OUTPUT"
           else
             echo 'os_matrix=["ubuntu", "alpine"]' >> "$GITHUB_OUTPUT"
           fi
-          # Image axis (used by build-hardened-variants + promote)
+
+          # Image axis (build-hardened-variants + promote).
           if [ -n "$ONLY_IMAGE" ]; then
-            echo "image_matrix=[\"$ONLY_IMAGE\"]" >> "$GITHUB_OUTPUT"
+            echo "image_matrix=$(csv_to_json "$ONLY_IMAGE")" >> "$GITHUB_OUTPUT"
           else
             echo 'image_matrix=["gha-tools", "dood", "dind", "dood-node", "dind-node", "dood-pnpm", "dind-pnpm", "dood-pnpm-gyp", "dind-pnpm-gyp", "dood-playwright", "dind-playwright", "dood-playwright-gyp", "dind-playwright-gyp"]' >> "$GITHUB_OUTPUT"
           fi
-          # Flavor axis (used by promote). 'all' = no filter.
-          # ''  = hardened (consumer default), '-sudoer' = build-chain.
-          if [ "$ONLY_FLAVOR" = "all" ] || [ -z "$ONLY_FLAVOR" ]; then
-            echo 'flavor_matrix=["", "-sudoer"]' >> "$GITHUB_OUTPUT"
+
+          # Flavor axis (promote). Friendly names in / matrix values out:
+          # 'hardened' → '' (consumer default) | 'sudoer' → '-sudoer' (build-chain).
+          if [ -n "$ONLY_FLAVOR" ]; then
+            echo "flavor_matrix=$(csv_to_json "$ONLY_FLAVOR" "hardened= sudoer=-sudoer")" >> "$GITHUB_OUTPUT"
           else
-            echo "flavor_matrix=[\"$ONLY_FLAVOR\"]" >> "$GITHUB_OUTPUT"
+            echo 'flavor_matrix=["", "-sudoer"]' >> "$GITHUB_OUTPUT"
           fi
 
       # Structural lint: any smoke YAML that issues a `docker` command must bind the


### PR DESCRIPTION
## Why

Follow-up to #28. The single-select dropdowns forced one OS + one
image + one flavor per build-request issue. For the common cases
("rebuild both flavors of dind-playwright-gyp at pnpm 10", "give me
the whole fleet at ubuntu 22.04"), that meant filing 2-26 separate
issues. Switching the form to multi-select + optional collapses
those into one issue.

## What changes

**Convention:** an empty field on any axis (os / image / flavor)
means "build all default values of that axis". Same rule on all
three, on both the form and the `workflow_call` inputs.

- **Issue template**
  - `image` becomes multi-select (`multiple: true`). Empty = all 13.
  - `os` becomes multi-select + optional. Empty = both ubuntu and
    alpine (~2x wall-clock).
  - `flavor` becomes multi-select + optional. Empty = both hardened
    and sudoer (~2x promote).
  - `os_version` is now optional too; empty falls through to the
    per-OS Dockerfile `ARG OS_VERSION` default.
  - All `required: true` validations dropped; `default: 0` on
    flavor dropped. Empty everywhere is now valid and means "the
    whole fleet at requested versions" (~30 min full chain rebuild).

- **`test-and-publish.yml`**
  - `only_os` / `only_image` / `only_flavor` accept CSV
    (`'ubuntu,alpine'`, `'dood-playwright,dind-playwright'`,
    `'hardened,sudoer'`). Whitespace around commas tolerated.
  - The `'all'` sentinel on `only_flavor` is dropped; empty now
    means "no filter" for all three axes.
  - Tiny `csv_to_json` helper in the matrices step with an optional
    friendly→matrix-value map (used for flavor:
    `hardened=` and `sudoer=-sudoer`). Unknown values error out
    loudly so a typo in an issue body fails here rather than
    expanding to a never-matching matrix cell.

- **`on-demand-build.yml`**
  - The flavor case-conversion in `parse` is gone; friendly names
    pass through to `only_flavor` directly.
  - The `predict` step + docker-manifest `existing` precheck are
    dropped. With multi-select axes the prediction would have to fan
    out across every combination; an unchanged-digest re-push is a
    no-op anyway, so the cost of dropping the precheck is one
    rebuild on the rare fully-redundant request.
  - `notify-start` no longer cites a specific predicted tag; the
    success comment links to the Docker Hub user page (actual
    published tags).

## Retrocompat

Push/PR path is byte-identical to today: all `inputs.*` are
null/empty on push → matrices step falls through to the full
defaults → same matrix shape as `main` today.

Existing single-select on-demand callers (none in the wild yet —
this builds on #28 which is days-old) keep working: passing a
single `os: 'ubuntu'` / `image: 'dood-playwright'` /
`flavor: 'hardened'` parses fine through CSV.

## Bootstrap (manual, one-time)

Issue #30 surfaced that the `build-request` label has to exist in
the repo for the issue template's `labels: ["build-request"]` to
take. Run once:

```
gh label create build-request \
  --description "On-demand build request from the issue template" \
  --color 0E8A16
```

(Or apply the label manually to existing requests like #30 — but
note the workflow only fires on `issues: [opened]`, not on
`labeled`, so #30 needs to be re-filed as a new issue after the
label exists.)

## Test plan

- [x] YAML validation of all three files
- [x] Local sanity test of `csv_to_json` (simple, whitespace,
      friendly-map, error case)
- [ ] PR CI run — full matrix on the PR path (proves push/PR
      semantics unchanged).
- [ ] After merge + label bootstrap: open a test issue selecting
      `image=[dood-playwright,dind-playwright]`,
      `flavor=[hardened,sudoer]`, leaving `os` empty. Expect: 1
      build job, 2 OSes × 2 images × 2 flavors = 8 promote cells,
      no `:latest` push.

## Out of scope (named so reviewers don't ask)

- Reinstating an `existing`-tag precheck that handles multi-axis
  cleanly. Would need to enumerate the cross product and inspect
  each; defer until it's actually needed.
- A `gh label create build-request` step inside the workflow.
  Chicken-and-egg: the workflow's `if:` filter checks the label, so
  it can't bootstrap itself. Will live in repo setup docs.
- Wiring the actual pinned tag(s) from `promote` back out as a
  `workflow_call` output (so the success comment can list them).
  Tracked as an open question in #28's body; revisit if it becomes
  important.

Assisted-by: Claude:claude-opus-4-7
