### PR TITLE
feat(dind): auto-spawn ci-prebuilds-dind-registry on host for act shards

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1284,6 +1284,42 @@ jobs:
 
 
   # ----------------------------------------------------------------------------
+  # act: exercise the DIND_REGISTRY_AUTOSTART path — the dind image auto-spawns
+  # `ci-prebuilds-dind-registry` on the host docker daemon (reached via the
+  # bind-mounted host socket) and points its inner dockerd at it via
+  # registry-mirrors. Piggybacks the `dood_dind` filter — no new filter key.
+  # ----------------------------------------------------------------------------
+
+  test-dind-registry-autostart:
+    runs-on: ubuntu-latest
+    if: fromJSON(needs.github-context.outputs.test_filters).dood_dind
+    needs: [github-context, build-dind]
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.github-context.outputs.os_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install act
+        run: curl -sSL "https://raw.githubusercontent.com/nektos/act/v${ACT_VERSION}/install.sh" | sudo bash -s -- -b /usr/local/bin
+      - name: Pre-pull the container image
+        run: docker pull "ghcr.io/jclaveau/${{ matrix.os }}-dind:${{ needs.github-context.outputs.build_tag }}"
+      - name: Run the autostart smoke workflow through act
+        env:
+          IMG: ghcr.io/jclaveau/${{ matrix.os }}-dind:${{ needs.github-context.outputs.build_tag }}
+        run: |
+          act push -W tests/act/smoke-dind-registry-autostart.yml \
+            -P ubuntu-latest=-self-hosted \
+            --var RUNNER_IMAGE="$IMG"
+
+
+  # ----------------------------------------------------------------------------
   # Versions: read the actual installed minors once from the top dood image (it
   # transitively contains OS + node + pnpm + playwright). `promote` turns these
   # into the version-pinned consumer tags. node is read from the image because its
@@ -1391,7 +1427,7 @@ jobs:
         # '-sudoer' = build-chain image (runner NOPASSWD: ALL intact)
         #   → publishes to `<image>-sudoer:latest`.
         flavor: ${{ fromJSON(needs.github-context.outputs.flavor_matrix) }}
-    needs: [github-context, versions, build-hardened-variants, test-gha-tools-usage, test-gha-tools-effects, test-dind-hardened-effects, test-dood-dind-usage, test-dood-dind-effects, test-dood-dind-act, test-node-usage, test-pnpm-usage, test-pnpm-gyp-usage, test-playwright-usage]
+    needs: [github-context, versions, build-hardened-variants, test-gha-tools-usage, test-gha-tools-effects, test-dind-hardened-effects, test-dood-dind-usage, test-dood-dind-effects, test-dood-dind-act, test-dind-registry-autostart, test-node-usage, test-pnpm-usage, test-pnpm-gyp-usage, test-playwright-usage]
     steps:
       - uses: docker/setup-buildx-action@v3
       # GHCR login to READ the tested source image.

--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -14,7 +14,7 @@ RUN sudo chmod 0755 /usr/local/bin/start-dockerd
 # the hardened flavor — but `sudo apt-get install …` etc. stay denied.
 # `visudo -c` validates the file at build time; a typo would otherwise break
 # ALL sudo at runtime.
-RUN echo "runner ALL=(root) NOPASSWD: /usr/sbin/dockerd, /usr/bin/chown root\:docker /var/run/dind.sock, /usr/bin/chmod 660 /var/run/dind.sock" \
+RUN echo "runner ALL=(root) NOPASSWD: /usr/sbin/dockerd, /usr/bin/chown root\:docker /var/run/dind.sock, /usr/bin/chmod 660 /var/run/dind.sock, /usr/bin/chown root\:docker /var/run/docker.sock, /usr/bin/chmod 660 /var/run/docker.sock, /usr/bin/tee /etc/docker/daemon.json" \
       | sudo install -m 0440 /dev/stdin /etc/sudoers.d/dind \
     && sudo visudo -c -f /etc/sudoers.d/dind
 

--- a/dind/Dockerfile.alpine
+++ b/dind/Dockerfile.alpine
@@ -14,7 +14,7 @@ RUN sudo chmod 0755 /usr/local/bin/start-dockerd
 # the hardened flavor — but `sudo apk add …` etc. stay denied.
 # `visudo -c` validates the file at build time; a typo would otherwise break
 # ALL sudo at runtime.
-RUN echo "runner ALL=(root) NOPASSWD: /usr/sbin/dockerd, /usr/bin/chown root\:docker /var/run/dind.sock, /usr/bin/chmod 660 /var/run/dind.sock" \
+RUN echo "runner ALL=(root) NOPASSWD: /usr/sbin/dockerd, /usr/bin/chown root\:docker /var/run/dind.sock, /usr/bin/chmod 660 /var/run/dind.sock, /usr/bin/chown root\:docker /var/run/docker.sock, /usr/bin/chmod 660 /var/run/docker.sock, /usr/bin/tee /etc/docker/daemon.json" \
       | sudo install -m 0440 /dev/stdin /etc/sudoers.d/dind \
     && sudo visudo -c -f /etc/sudoers.d/dind
 

--- a/dind/README.md
+++ b/dind/README.md
@@ -43,3 +43,52 @@ jobs:
       - run: docker compose -f docker-compose-tests.yaml up -d --wait
       - run: nc -zv localhost 5432
 ```
+
+## Auto-shared pull-through cache for `act` shards
+
+`act` matrix shards on a dev machine each spin up their own dind, and each
+inner `dockerd` re-pulls the same base images — duplicated bandwidth × shard
+count. The dind images can auto-spawn a `registry:2` container on the
+HOST docker daemon (named `ci-prebuilds-dind-registry`, port `36000`,
+upstream `mirror.gcr.io`) and point every inner dockerd at it via
+`registry-mirrors`. First shard to start wins; siblings detect it via
+`docker inspect` and no-op.
+
+**One-time setup** — drop into `~/.actrc` (or project-local `./.actrc`):
+
+```
+-P ubuntu-latest=ghcr.io/jclaveau/ubuntu-dind:latest
+--container-options=--privileged
+--container-options=-v /var/run/docker.sock:/var/run/docker.sock
+--container-options=--add-host=host.docker.internal:host-gateway
+--container-options=-e DIND_REGISTRY_AUTOSTART=1
+```
+
+**Per-run cost** — none. `act` (no extra flags). The first invocation
+brings up `ci-prebuilds-dind-registry`; every subsequent invocation and
+every sharded sibling re-uses it.
+
+**Inspect / wipe** the cache from the host:
+
+```
+docker logs ci-prebuilds-dind-registry
+docker volume inspect ci-prebuilds-dind-registry-data
+docker rm -f ci-prebuilds-dind-registry && docker volume rm ci-prebuilds-dind-registry-data
+```
+
+**Explicit endpoint** — set `DIND_REGISTRY_MIRROR=http://your-host:port` to
+point the inner dockerd at a registry you run elsewhere. Autostart only
+defaults the var when unset.
+
+**Caveats**
+- Bind-mounting `/var/run/docker.sock` gives the dind workload host-Docker
+  control. Acceptable for `act`-on-dev-machine; **do not enable on hosted
+  GHA runners** (autostart silently falls through when the host socket is
+  absent, but the bind-mount itself shouldn't be configured there).
+- `--add-host=host.docker.internal:host-gateway` is required on Linux for
+  the inner dockerd to resolve the host endpoint; harmless on Docker
+  Desktop where it's native.
+- Autostart silently falls through to no-mirror if (a) `/var/run/docker.sock`
+  isn't a socket or (b) the registry takes >15 s to come up. To diagnose,
+  read `/tmp/dockerd.log` inside the dind or `docker ps` on the host.
+

--- a/dind/start-dockerd.sh
+++ b/dind/start-dockerd.sh
@@ -4,6 +4,56 @@
 #   docker run / act:   ENTRYPOINT runs it, then execs CMD (sleep infinity)
 set -euo pipefail
 
+# Optional pull-through cache for `act` shards on a dev machine.
+# When DIND_REGISTRY_AUTOSTART is truthy AND /var/run/docker.sock is bind-
+# mounted from the host, idempotently bring up a `ci-prebuilds-dind-registry`
+# container on the HOST docker daemon and point this inner dockerd at it
+# via registry-mirrors. All sibling shards race the same docker-run; the
+# first wins, the rest no-op via `inspect` + `|| true`.
+# Silent fallback paths (warn → no-mirror, dockerd still boots cleanly):
+#   - DIND_REGISTRY_AUTOSTART truthy but no host socket present (e.g. on
+#     hosted GHA runners that didn't bind it). Autostart is dev-loop-only.
+#   - Registry health-probe times out (>15s). The dind still boots; pulls
+#     just go direct to upstream.
+case "${DIND_REGISTRY_AUTOSTART:-}" in
+  1|true|TRUE|yes|YES)
+    if [ -S /var/run/docker.sock ]; then
+      # Make the host socket usable by `runner` without sudo: chown to the
+      # in-container `docker` group (GID may differ from host's, which is
+      # why we chown rather than rely on the bind-mounted host perms).
+      sudo chown root:docker /var/run/docker.sock
+      sudo chmod 660 /var/run/docker.sock
+      HOST_DOCKER="docker -H unix:///var/run/docker.sock"
+      $HOST_DOCKER inspect ci-prebuilds-dind-registry >/dev/null 2>&1 \
+        || $HOST_DOCKER run -d --restart=unless-stopped \
+             --name ci-prebuilds-dind-registry \
+             -p 36000:5000 \
+             -v ci-prebuilds-dind-registry-data:/var/lib/registry \
+             -e REGISTRY_PROXY_REMOTEURL=https://mirror.gcr.io \
+             mirror.gcr.io/library/registry:2 \
+           >/dev/null 2>&1 || true
+      $HOST_DOCKER start ci-prebuilds-dind-registry >/dev/null 2>&1 || true
+      if timeout 15 bash -c 'until curl -fsS http://host.docker.internal:36000/v2/ >/dev/null 2>&1; do sleep 1; done'; then
+        : "${DIND_REGISTRY_MIRROR:=http://host.docker.internal:36000}"
+        export DIND_REGISTRY_MIRROR
+      else
+        echo "DIND_REGISTRY_AUTOSTART: registry health-probe timed out; continuing without mirror" >&2
+      fi
+    else
+      echo "DIND_REGISTRY_AUTOSTART set but /var/run/docker.sock not bind-mounted; continuing without mirror" >&2
+    fi
+    ;;
+esac
+
+# Rewrite /etc/docker/daemon.json with a registry-mirrors entry when a mirror
+# resolved (autostart above OR explicit user input). Otherwise leave the
+# Dockerfile-baked log-only daemon.json untouched.
+if [ -n "${DIND_REGISTRY_MIRROR:-}" ]; then
+  printf '%s\n' \
+    "{\"log-driver\":\"json-file\",\"log-opts\":{\"max-size\":\"10m\",\"max-file\":\"3\"},\"registry-mirrors\":[\"${DIND_REGISTRY_MIRROR}\"]}" \
+    | sudo tee /etc/docker/daemon.json >/dev/null
+fi
+
 # Empty => dockerd auto-selects (overlay2 where supported).
 # Override for portability (act on btrfs/zfs/rootless): DOCKER_STORAGE_DRIVER=vfs|overlay2|fuse-overlayfs
 driver=""

--- a/tests/act/smoke-dind-registry-autostart.yml
+++ b/tests/act/smoke-dind-registry-autostart.yml
@@ -4,11 +4,14 @@
 # dockerd at it via registry-mirrors.
 # Container options:
 #   --privileged: required for the inner dockerd as on the plain smoke-dind test.
-#   -v /var/run/docker.sock:/var/run/docker.sock: gives the dind access to the
-#       host's docker daemon so it can `docker run registry:2` on the host.
 #   --add-host=host.docker.internal:host-gateway: lets the inner dockerd resolve
 #       the host endpoint on Linux (no-op on Docker Desktop where it's native).
 #   -e DIND_REGISTRY_AUTOSTART=1: flips the gated block in start-dockerd.sh.
+# NOTE: no explicit `-v /var/run/docker.sock:/var/run/docker.sock` here — `act`
+# auto-mounts the host docker socket into every container by default; adding it
+# explicitly errors with "Duplicate mount point". The end-user `.actrc` recipe
+# in dind/README.md DOES include the mount because there's no outer act in
+# that case.
 # Kept out of .github/workflows so real CI ignores it.
 name: act smoke (dind registry autostart)
 on: [push]
@@ -20,7 +23,6 @@ jobs:
       options: >-
         --privileged
         --env DOCKER_HOST=unix:///var/run/dind.sock
-        -v /var/run/docker.sock:/var/run/docker.sock
         --add-host=host.docker.internal:host-gateway
         -e DIND_REGISTRY_AUTOSTART=1
     env:

--- a/tests/act/smoke-dind-registry-autostart.yml
+++ b/tests/act/smoke-dind-registry-autostart.yml
@@ -1,0 +1,56 @@
+# Smoke workflow run through `act` to exercise the DIND_REGISTRY_AUTOSTART path:
+# the dind image auto-spawns `ci-prebuilds-dind-registry` on the HOST docker
+# daemon (reached via the bind-mounted host socket) and points the inner
+# dockerd at it via registry-mirrors.
+# Container options:
+#   --privileged: required for the inner dockerd as on the plain smoke-dind test.
+#   -v /var/run/docker.sock:/var/run/docker.sock: gives the dind access to the
+#       host's docker daemon so it can `docker run registry:2` on the host.
+#   --add-host=host.docker.internal:host-gateway: lets the inner dockerd resolve
+#       the host endpoint on Linux (no-op on Docker Desktop where it's native).
+#   -e DIND_REGISTRY_AUTOSTART=1: flips the gated block in start-dockerd.sh.
+# Kept out of .github/workflows so real CI ignores it.
+name: act smoke (dind registry autostart)
+on: [push]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.RUNNER_IMAGE }}
+      options: >-
+        --privileged
+        --env DOCKER_HOST=unix:///var/run/dind.sock
+        -v /var/run/docker.sock:/var/run/docker.sock
+        --add-host=host.docker.internal:host-gateway
+        -e DIND_REGISTRY_AUTOSTART=1
+    env:
+      DOCKER_STORAGE_DRIVER: fuse-overlayfs
+    steps:
+      - run: start-dockerd
+      - name: Inner dockerd has the mirror configured
+        run: |
+          docker info 2>&1 | tee /tmp/info.txt
+          grep -F 'http://host.docker.internal:36000' /tmp/info.txt
+      - name: Host docker has the ci-prebuilds-dind-registry container running
+        run: |
+          docker -H unix:///var/run/docker.sock inspect ci-prebuilds-dind-registry \
+            --format '{{.State.Status}}' | tee /tmp/state.txt
+          grep -Fx running /tmp/state.txt
+      - name: First pull populates the cache
+        run: docker pull mirror.gcr.io/library/hello-world
+      - name: Second pull serves from the cache
+        # Trigger by-digest re-pull on a freshly removed local copy; the
+        # registry logs the hit. We then grep for a cache-style line.
+        run: |
+          docker rmi mirror.gcr.io/library/hello-world
+          docker pull mirror.gcr.io/library/hello-world
+          docker -H unix:///var/run/docker.sock logs ci-prebuilds-dind-registry 2>&1 \
+            | tee /tmp/reg.log
+          # The pull-through proxy mode logs blob/manifest requests; just
+          # assert the registry handled traffic for the pulled name.
+          grep -F 'hello-world' /tmp/reg.log
+      - name: Cleanup (so re-runs on the same host start from a clean state)
+        if: always()
+        run: |
+          docker -H unix:///var/run/docker.sock rm -f ci-prebuilds-dind-registry || true
+          docker -H unix:///var/run/docker.sock volume rm ci-prebuilds-dind-registry-data || true

--- a/tests/act/smoke-dind-registry-autostart.yml
+++ b/tests/act/smoke-dind-registry-autostart.yml
@@ -39,17 +39,19 @@ jobs:
             --format '{{.State.Status}}' | tee /tmp/state.txt
           grep -Fx running /tmp/state.txt
       - name: First pull populates the cache
-        run: docker pull mirror.gcr.io/library/hello-world
+        # Unqualified name → docker.io → matched by registry-mirrors, so the
+        # inner dockerd routes the pull through ci-prebuilds-dind-registry.
+        # The registry is a pull-through cache for mirror.gcr.io upstream,
+        # so this stays egress-stable (no Docker Hub direct dependency).
+        run: docker pull library/hello-world
       - name: Second pull serves from the cache
-        # Trigger by-digest re-pull on a freshly removed local copy; the
-        # registry logs the hit. We then grep for a cache-style line.
+        # Force a re-pull; the registry should log requests for the
+        # hello-world repository in pull-through proxy mode.
         run: |
-          docker rmi mirror.gcr.io/library/hello-world
-          docker pull mirror.gcr.io/library/hello-world
+          docker rmi library/hello-world
+          docker pull library/hello-world
           docker -H unix:///var/run/docker.sock logs ci-prebuilds-dind-registry 2>&1 \
             | tee /tmp/reg.log
-          # The pull-through proxy mode logs blob/manifest requests; just
-          # assert the registry handled traffic for the pulled name.
           grep -F 'hello-world' /tmp/reg.log
       - name: Cleanup (so re-runs on the same host start from a clean state)
         if: always()


### PR DESCRIPTION
## Why

Running `act` with matrix shards on a dev machine: each shard spins up its own dind with its own inner `dockerd`, each then re-pulls the same base images from upstream — duplicated bandwidth × shard count. Putting a `registry:2` inside one shard's dind doesn't help: sibling shards live in separate network namespaces and can't reach it. The cache has to live on the **host**, shared via the bind-mounted host socket.

I want this to be zero-per-run-setup: drop one `.actrc` stanza and forget about it.

## What

When `DIND_REGISTRY_AUTOSTART` is truthy **and** `/var/run/docker.sock` is bind-mounted, `start-dockerd.sh` now:
1. chowns the host socket so the in-container `runner` user can drive host docker without `sudo`,
2. idempotently `docker run`s `ci-prebuilds-dind-registry` (named, restart=unless-stopped, port 36000 → 5000, named volume `ci-prebuilds-dind-registry-data`, `REGISTRY_PROXY_REMOTEURL=https://mirror.gcr.io`) on the host daemon,
3. health-polls `http://host.docker.internal:36000/v2/` for up to 15 s,
4. rewrites `/etc/docker/daemon.json` to include `registry-mirrors`,
5. boots the inner dockerd as before.

All shards race step 2; the first wins, the rest no-op via `inspect` + `|| true`. The `docker start` follow-up + tolerant `|| true` cover the inspect-but-stopped case.

## Default-path retrocompat

Existing users unaffected. With `DIND_REGISTRY_AUTOSTART` unset (the default, including on hosted GHA), the new block is a `case`-gated no-op. The sudoers entries are additive (three narrow allow-commands, no wildcard). The daemon.json rewrite only fires when `DIND_REGISTRY_MIRROR` resolved (either via autostart or explicit env). Misconfigured autostart (env on, socket missing, or registry slow to come up) warns to stderr and falls through to no-mirror so dind still boots.

## Out of scope (named so reviewers don't have to ask)

- **Multi-upstream caching** (Docker Hub + GHCR + …). `registry:2` is single-upstream. A future iteration could spin up N registries on distinct ports and list them all under `registry-mirrors`, or swap in `rpardini/docker-registry-proxy`.
- **TLS / auth**. Loopback HTTP is fine; authed upstreams need credential plumbing as a separate design.
- **GC of the cache volume**. Manual via `docker volume rm` for now.
- **Hosted GHA** as a target. The autostart path needs a bind-mounted host socket, which is a dev-loop choice, not a CI one.

## CI coverage

New `test-dind-registry-autostart` job in `test-and-publish.yml` runs the smoke through `act` per-OS (`alpine`, `ubuntu`), gated on the existing `test_filters.dood_dind` filter. The smoke asserts: (a) inner dockerd has the mirror in `docker info`, (b) the sidecar is running on the GHA runner's host docker, (c) a first pull succeeds, (d) a second pull triggers a hit in the registry's logs.

Added to `promote.needs:` — the existing `!failure() && !cancelled()` gate already tolerates the skipped-by-filter path on narrowed on-demand runs.

## Open questions for the reviewer

- The sudoers chown/chmod on `/var/run/docker.sock` mutates **host-side** socket perms (chown to `root:<in-container docker GID>`). On a dev machine where the user owns both sides that's a wash, but it's a one-way operation per dind boot. Worth noting in the README more loudly?
- The cleanup `docker rm -f ... && docker volume rm ...` in the smoke runs on the GHA runner's host docker (post-job), so cell-to-cell isolation is preserved. But if two cells of this matrix race the same runner image, the second cell's autostart will inspect→found→reuse a stale registry from cell 1 — fine semantically, less of a clean test. Acceptable?
- I followed the plan's "no wildcard `docker` allow" line by chowning the socket; alternative was a sudoers wildcard for `docker -H unix:///var/run/docker.sock *`. Happy to flip if you prefer.

Assisted-by: Claude:claude-opus-4-7