### PR TITLE
feat: alpine playwright image ships musl chromium-headless-shell

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1184,21 +1184,20 @@ jobs:
       - run: pnpm playwright test
         working-directory: playwright
 
-      # Alpine-only: validate the documented `playwright.config.ts` contract from
-      # playwright/README.md. The image installs system Chromium at
-      # /usr/bin/chromium-browser but Playwright doesn't probe for it — vanilla
-      # consumers without the documented launchOptions snippet see "Executable
-      # doesn't exist". This step pins that behavior so we'll know the day
-      # Playwright upstream changes its resolution semantics (e.g. starts
-      # discovering /usr/bin/chromium-browser).
-      - name: Alpine — vanilla config FAILS; documented snippet PASSES
+      # Alpine-only: pin the documented `playwright.config.ts` contract from
+      # playwright/README.md. The image now stages musl-native
+      # chromium-headless-shell at PW SDK's auto-discovery cache path
+      # (PLAYWRIGHT_BROWSERS_PATH=/ms-playwright), so a vanilla config (no
+      # executablePath, no launchOptions) MUST work — that's the "drop-in
+      # replacement" promise. This step pins that behavior so we'll know the
+      # day PW SDK changes its auto-discovery semantics or our staging path
+      # drifts.
+      - name: Alpine — vanilla config PASSES (auto-discovery via cache path)
         if: matrix.os == 'alpine'
         run: |
           mkdir -p /tmp/pw-vanilla && cd /tmp/pw-vanilla
           echo '{"name":"v","version":"1.0.0"}' > package.json
           pnpm add -D @playwright/test
-
-          # Step 1 — vanilla config: must fail with "Executable doesn't exist"
           cat > playwright.config.ts <<'TS'
           import { defineConfig } from '@playwright/test';
           export default defineConfig({ projects: [{ name: 'chromium' }] });
@@ -1206,21 +1205,6 @@ jobs:
           cat > example.spec.ts <<'TS'
           import { test } from '@playwright/test';
           test('hello', async ({ page }) => { await page.goto('about:blank'); });
-          TS
-          if pnpm playwright test 2>&1 | tee /tmp/pw-out.log | grep -qE "Executable doesn'?t exist"; then
-            echo "OK: vanilla config fails as documented"
-          else
-            cat /tmp/pw-out.log
-            echo "FAIL: expected 'Executable doesn't exist' error with vanilla config"
-            exit 1
-          fi
-
-          # Step 2 — documented snippet (executablePath = /usr/bin/chromium-browser): must pass
-          cat > playwright.config.ts <<'TS'
-          import { defineConfig, devices } from '@playwright/test';
-          export default defineConfig({
-            projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'], launchOptions: { executablePath: '/usr/bin/chromium-browser' } } }],
-          });
           TS
           pnpm playwright test
 

--- a/alpine-gha-tools/Dockerfile
+++ b/alpine-gha-tools/Dockerfile
@@ -3,14 +3,7 @@
 # limit in CI: the rest of the pipeline builds/pulls via GHCR, so CI does zero Docker Hub pulls.
 # Renovate keeps the default pinned; the workflow_call path overrides OS_VERSION for on-demand
 # requests targeting a different Alpine (e.g. 3.20). Default = current consumer pin.
-# Bumped 3.21 → edge so the playwright/Dockerfile.alpine consumer's FF
-# artifact (built by the playwright-alpine-browsers producer on alpine edge,
-# ICU 78) finds matching system .so versions. Alpine 3.21 ships ICU 74,
-# 3.22/3.23 ship ICU 76 — only edge ships ICU 78. Trade-off: rolling-release
-# churn on the alpine base in exchange for ABI alignment with the producer
-# artifact. Long-term alternative: bundle libicu*.so into the FF producer
-# artifact (ldd-walk like chromium-headless-shell) and revert this.
-ARG OS_VERSION=edge
+ARG OS_VERSION=3.21
 FROM public.ecr.aws/docker/library/alpine:${OS_VERSION}
 
 # Alpine/musl counterpart of ubuntu-gha-tools: the same accounts, env, curated OS tooling and the

--- a/alpine-gha-tools/Dockerfile
+++ b/alpine-gha-tools/Dockerfile
@@ -3,7 +3,14 @@
 # limit in CI: the rest of the pipeline builds/pulls via GHCR, so CI does zero Docker Hub pulls.
 # Renovate keeps the default pinned; the workflow_call path overrides OS_VERSION for on-demand
 # requests targeting a different Alpine (e.g. 3.20). Default = current consumer pin.
-ARG OS_VERSION=3.21
+# Bumped 3.21 → edge so the playwright/Dockerfile.alpine consumer's FF
+# artifact (built by the playwright-alpine-browsers producer on alpine edge,
+# ICU 78) finds matching system .so versions. Alpine 3.21 ships ICU 74,
+# 3.22/3.23 ship ICU 76 — only edge ships ICU 78. Trade-off: rolling-release
+# churn on the alpine base in exchange for ABI alignment with the producer
+# artifact. Long-term alternative: bundle libicu*.so into the FF producer
+# artifact (ldd-walk like chromium-headless-shell) and revert this.
+ARG OS_VERSION=edge
 FROM public.ecr.aws/docker/library/alpine:${OS_VERSION}
 
 # Alpine/musl counterpart of ubuntu-gha-tools: the same accounts, env, curated OS tooling and the

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -2,18 +2,73 @@
 ARG BASE_IMAGE=jclaveau/alpine-dood-pnpm:latest
 FROM ${BASE_IMAGE}
 
-# Renovate will update this
+# Renovate will update this in lockstep with the producer image's published
+# tags. Same PW_VERSION drives `pnpm install -g playwright@…` AND the
+# COPY --from tags below — they must match (PW SDK reads its bundled
+# browsers.json to know the expected revision in the cache path).
 ARG PLAYWRIGHT_VERSION=1.50.1
 
-LABEL org.opencontainers.image.description="Playwright (system Chromium) in Alpine based DinD as Github Actions Container"
+# Browser-artifact revisions — derived from PW's browsers.json upstream and
+# published as stable tags by the `playwright-alpine-browsers.yml` producer
+# workflow. When PW bumps a revision, Renovate's custom manager bumps these
+# in lockstep with PLAYWRIGHT_VERSION above.
+ARG FF_REV=1522
+ARG CHS_REV=1223
 
-# Playwright's bundled browsers are glibc-only and `playwright install --with-deps` runs apt — neither
-# works on Alpine/musl. So install Alpine's own Chromium + its runtime libs/fonts and point Playwright
-# at /usr/bin/chromium-browser via `launchOptions: { executablePath: ... }` in your config. Chromium-only:
-# there are no official Firefox/WebKit musl builds. SKIP_BROWSER_DOWNLOAD stops both the image build and
-# the test's `pnpm install` from fetching the (glibc) bundled browsers.
+LABEL org.opencontainers.image.description="Playwright (musl-native chromium-headless-shell + Firefox) in Alpine based DinD as Github Actions Container"
+
+# Playwright's bundled browsers are glibc-only and `playwright install
+# --with-deps` runs apt — neither works on Alpine/musl. We stage musl-built
+# browsers from our producer image at PW SDK's auto-discovery cache path; the
+# SDK finds them via PLAYWRIGHT_BROWSERS_PATH lookup at launch time. No
+# executablePath override required in playwright.config.ts.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+# Suppresses PW's "musl not supported" warning — its hostPlatform.ts detects
+# `linux-musl` but its DOWNLOAD_PATHS table has no entry. Safe because we
+# PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 anyway; no download is attempted.
+ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24
 
-RUN echo "Install Alpine Chromium + Playwright CLI (system Chromium is used; no browser download)" \
-    && sudo apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont \
-    && pnpm install -g playwright@${PLAYWRIGHT_VERSION}
+# Firefox — musl-built, PW-patched. The producer artifact ships the dist tree
+# at /firefox; we stage it where PW SDK looks for firefox-{rev}/firefox/.
+COPY --from=ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} \
+     /firefox \
+     /ms-playwright/firefox-${FF_REV}/firefox
+RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
+ && sudo chmod 755 /ms-playwright/firefox-${FF_REV}
+
+# Juggler-activation workaround — on our musl FF build (and also on glibc
+# with the same patches; see ~/.claude/plans/as-alpine-is-the-synchronous-
+# kahan.md §FF root-cause-status), PW's `m-remote` command-line-handler is
+# shadowed by Mozilla's RemoteAgent in static_components dedup. `-juggler-pipe`
+# alone is silent. Activating Mozilla's RemoteAgent via `--remote-debugging-
+# port=0` side-effects Juggler into life. Wrap the binary with a 4-line shim
+# that prepends the flag. Drop this block once a build-side Juggler self-
+# bootstrap fix lands in the producer.
+RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
+            /ms-playwright/firefox-${FF_REV}/firefox/firefox.real \
+ && printf '%s\n' \
+        '#!/bin/sh' \
+        'exec "$(dirname "$0")/firefox.real" --remote-debugging-port=0 "$@"' \
+  | sudo tee /ms-playwright/firefox-${FF_REV}/firefox/firefox >/dev/null \
+ && sudo chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox
+
+# chromium-headless-shell — apk-extracted, self-contained via RPATH=$ORIGIN.
+# Smaller artifact than full chromium; deterministic timing for tests.
+COPY --from=ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} \
+     /chrome-headless-shell-linux64 \
+     /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64
+RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_COMPLETE \
+ && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV}
+
+# Runtime libs. Chromium artifact is self-contained (RPATH=$ORIGIN), but the
+# musl Firefox build dynamically links against system libs per aports'
+# mozconfig — install the runtime deps from aports' community/firefox
+# `depends=` minus things headless doesn't load.
+RUN sudo apk add --no-cache \
+        ca-certificates font-opensans ttf-freefont \
+        alsa-lib dbus-libs fontconfig glib gtk+3.0 harfbuzz icu-libs \
+        libdrm libevent libffi libjpeg-turbo libnotify libogg libtheora \
+        libvorbis libvpx libwebp libwebpdemux libxcomposite libxt mesa-gl \
+        nspr nss pipewire-libs libpulse \
+ && pnpm install -g playwright@${PLAYWRIGHT_VERSION}

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -22,7 +22,7 @@ ARG CHS_REV
 # tags. Same PW_VERSION drives `pnpm install -g playwright@…` AND the
 # COPY --from tags above — they must match (PW SDK reads its bundled
 # browsers.json to know the expected revision in the cache path).
-ARG PLAYWRIGHT_VERSION=1.50.1
+ARG PLAYWRIGHT_VERSION=1.60.0
 
 LABEL org.opencontainers.image.description="Playwright (musl-native chromium-headless-shell + Firefox) in Alpine based DinD as Github Actions Container"
 

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -48,9 +48,14 @@ COPY --from=chs-source /chrome-headless-shell-linux64 /ms-playwright/chromium_he
 RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV}
 
-# Runtime: chromium-headless-shell artifact is self-contained (RPATH=$ORIGIN
-# bundles all its .so deps + system libs). Only ca-certificates + a font are
-# needed at runtime. pnpm install -g playwright pins the SDK to the same
-# version the producer used to derive the artifact revision.
-RUN sudo apk add --no-cache ca-certificates ttf-freefont \
+# Runtime. The chromium-headless-shell artifact is RPATH=$ORIGIN
+# self-contained for ELF resolution, but Chromium still touches the system
+# for config files (fontconfig) and dlopen'd helper libs (NSS, DBus, GLib)
+# even when the corresponding .so is bundled. List mirrors aports'
+# community/chromium `depends=`, trimmed to what headless actually loads.
+RUN sudo apk add --no-cache \
+        ca-certificates font-opensans ttf-freefont \
+        dbus-libs fontconfig glib harfbuzz \
+        libdrm libffi libjpeg-turbo libwebp libwebpdemux libxcomposite \
+        mesa-gl nspr nss \
  && pnpm install -g playwright@${PLAYWRIGHT_VERSION}

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -44,19 +44,26 @@ COPY --from=ff-source /firefox /ms-playwright/firefox-${FF_REV}/firefox
 RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/firefox-${FF_REV}
 
-# Juggler-activation workaround — on our musl FF build (and also on glibc
-# with the same patches; see ~/.claude/plans/as-alpine-is-the-synchronous-
-# kahan.md §FF root-cause-status), PW's `m-remote` command-line-handler is
-# shadowed by Mozilla's RemoteAgent in static_components dedup. `-juggler-pipe`
-# alone is silent. Activating Mozilla's RemoteAgent via `--remote-debugging-
-# port=0` side-effects Juggler into life. Wrap the binary with a 4-line shim
-# that prepends the flag. Drop this block once a build-side Juggler self-
-# bootstrap fix lands in the producer.
+# Firefox launch shim — wraps two workarounds:
+#  1. Juggler activation — on our musl FF build (and also on glibc with the
+#     same patches; see ~/.claude/plans/as-alpine-is-the-synchronous-kahan.md
+#     §FF root-cause-status), PW's `m-remote` command-line-handler is
+#     shadowed by Mozilla's RemoteAgent in static_components dedup.
+#     `-juggler-pipe` alone is silent; activating Mozilla's RemoteAgent via
+#     `--remote-debugging-port=0` side-effects Juggler into life. Drop this
+#     half once a build-side Juggler self-bootstrap fix lands in the producer.
+#  2. LD_LIBRARY_PATH — libxul.so was built by aports with a hardcoded
+#     `RUNPATH=/usr/lib/firefox`, but we stage the artifact at
+#     /ms-playwright/firefox-{rev}/firefox/. Without prepending the bundle
+#     dir to LD_LIBRARY_PATH, the loader fails to resolve libmozsandbox.so
+#     and other peer .so files. Drop this half once the producer patches
+#     libxul's RUNPATH to `$ORIGIN` via patchelf (mirrors chromium artifact).
 RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
             /ms-playwright/firefox-${FF_REV}/firefox/firefox.real \
  && printf '%s\n' \
         '#!/bin/sh' \
-        'exec "$(dirname "$0")/firefox.real" --remote-debugging-port=0 "$@"' \
+        'DIR="$(dirname "$0")"' \
+        'exec env LD_LIBRARY_PATH="$DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$DIR/firefox.real" --remote-debugging-port=0 "$@"' \
   | sudo tee /ms-playwright/firefox-${FF_REV}/firefox/firefox >/dev/null \
  && sudo chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox
 

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -1,19 +1,28 @@
 # syntax=mirror.gcr.io/docker/dockerfile:1
+
+# Global ARGs (visible in FROM lines below). BuildKit doesn't support ARG
+# expansion in `COPY --from=` URLs, so we alias the producer-image refs as
+# named build stages and COPY --from those names later.
+ARG FF_REV=1522
+ARG CHS_REV=1223
 ARG BASE_IMAGE=jclaveau/alpine-dood-pnpm:latest
+
+# Producer-image stage aliases — Renovate's custom manager bumps the tag
+# revisions in lockstep with PLAYWRIGHT_VERSION below.
+FROM ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} AS ff-source
+FROM ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} AS chs-source
+
 FROM ${BASE_IMAGE}
+
+# Re-declare so ${FF_REV}/${CHS_REV} expand in this stage's paths.
+ARG FF_REV
+ARG CHS_REV
 
 # Renovate will update this in lockstep with the producer image's published
 # tags. Same PW_VERSION drives `pnpm install -g playwright@…` AND the
-# COPY --from tags below — they must match (PW SDK reads its bundled
+# COPY --from tags above — they must match (PW SDK reads its bundled
 # browsers.json to know the expected revision in the cache path).
 ARG PLAYWRIGHT_VERSION=1.50.1
-
-# Browser-artifact revisions — derived from PW's browsers.json upstream and
-# published as stable tags by the `playwright-alpine-browsers.yml` producer
-# workflow. When PW bumps a revision, Renovate's custom manager bumps these
-# in lockstep with PLAYWRIGHT_VERSION above.
-ARG FF_REV=1522
-ARG CHS_REV=1223
 
 LABEL org.opencontainers.image.description="Playwright (musl-native chromium-headless-shell + Firefox) in Alpine based DinD as Github Actions Container"
 
@@ -31,9 +40,7 @@ ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24
 
 # Firefox — musl-built, PW-patched. The producer artifact ships the dist tree
 # at /firefox; we stage it where PW SDK looks for firefox-{rev}/firefox/.
-COPY --from=ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} \
-     /firefox \
-     /ms-playwright/firefox-${FF_REV}/firefox
+COPY --from=ff-source /firefox /ms-playwright/firefox-${FF_REV}/firefox
 RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/firefox-${FF_REV}
 
@@ -55,9 +62,7 @@ RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
 
 # chromium-headless-shell — apk-extracted, self-contained via RPATH=$ORIGIN.
 # Smaller artifact than full chromium; deterministic timing for tests.
-COPY --from=ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} \
-     /chrome-headless-shell-linux64 \
-     /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64
+COPY --from=chs-source /chrome-headless-shell-linux64 /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64
 RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV}
 

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -1,36 +1,40 @@
 # syntax=mirror.gcr.io/docker/dockerfile:1
 
 # Global ARGs (visible in FROM lines below). BuildKit doesn't support ARG
-# expansion in `COPY --from=` URLs, so we alias the producer-image refs as
-# named build stages and COPY --from those names later.
-ARG FF_REV=1522
+# expansion in `COPY --from=` URLs, so we alias the producer-image ref as
+# a named build stage and COPY --from that name later.
 ARG CHS_REV=1223
 ARG BASE_IMAGE=jclaveau/alpine-dood-pnpm:latest
 
-# Producer-image stage aliases — Renovate's custom manager bumps the tag
-# revisions in lockstep with PLAYWRIGHT_VERSION below.
-FROM ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} AS ff-source
+# Producer-image stage alias — Renovate's custom manager bumps the tag
+# revision in lockstep with PLAYWRIGHT_VERSION below.
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} AS chs-source
 
 FROM ${BASE_IMAGE}
 
-# Re-declare so ${FF_REV}/${CHS_REV} expand in this stage's paths.
-ARG FF_REV
+# Re-declare so ${CHS_REV} expands in this stage's paths.
 ARG CHS_REV
 
 # Renovate will update this in lockstep with the producer image's published
-# tags. Same PW_VERSION drives `pnpm install -g playwright@…` AND the
-# COPY --from tags above — they must match (PW SDK reads its bundled
+# tag. Same PW_VERSION drives `pnpm install -g playwright@…` AND the
+# COPY --from tag above — they must match (PW SDK reads its bundled
 # browsers.json to know the expected revision in the cache path).
 ARG PLAYWRIGHT_VERSION=1.60.0
 
-LABEL org.opencontainers.image.description="Playwright (musl-native chromium-headless-shell + Firefox) in Alpine based DinD as Github Actions Container"
+LABEL org.opencontainers.image.description="Playwright (musl-native chromium-headless-shell) in Alpine based DinD as Github Actions Container"
 
 # Playwright's bundled browsers are glibc-only and `playwright install
-# --with-deps` runs apt — neither works on Alpine/musl. We stage musl-built
-# browsers from our producer image at PW SDK's auto-discovery cache path; the
-# SDK finds them via PLAYWRIGHT_BROWSERS_PATH lookup at launch time. No
-# executablePath override required in playwright.config.ts.
+# --with-deps` runs apt — neither works on Alpine/musl. We stage the
+# musl-native chromium-headless-shell from our producer image at PW SDK's
+# auto-discovery cache path; the SDK finds it via PLAYWRIGHT_BROWSERS_PATH
+# lookup at launch time. No executablePath override required in
+# playwright.config.ts.
+#
+# Firefox is NOT shipped here (yet) — the producer artifact has a
+# cross-musl-version ABI mismatch when it runs on a different alpine base
+# than the producer was built on (edge vs 3.21). Follow-up to either match
+# alpine versions or scope the bundle correctly. See
+# ~/.claude/plans/as-alpine-is-the-synchronous-kahan.md for details.
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 # Suppresses PW's "musl not supported" warning — its hostPlatform.ts detects
@@ -38,49 +42,15 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 anyway; no download is attempted.
 ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24
 
-# Firefox — musl-built, PW-patched. The producer artifact ships the dist tree
-# at /firefox; we stage it where PW SDK looks for firefox-{rev}/firefox/.
-COPY --from=ff-source /firefox /ms-playwright/firefox-${FF_REV}/firefox
-RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
- && sudo chmod 755 /ms-playwright/firefox-${FF_REV}
-
-# Firefox launch shim — wraps two workarounds:
-#  1. Juggler activation — on our musl FF build (and also on glibc with the
-#     same patches; see ~/.claude/plans/as-alpine-is-the-synchronous-kahan.md
-#     §FF root-cause-status), PW's `m-remote` command-line-handler is
-#     shadowed by Mozilla's RemoteAgent in static_components dedup.
-#     `-juggler-pipe` alone is silent; activating Mozilla's RemoteAgent via
-#     `--remote-debugging-port=0` side-effects Juggler into life. Drop this
-#     half once a build-side Juggler self-bootstrap fix lands in the producer.
-#  2. LD_LIBRARY_PATH — libxul.so was built by aports with a hardcoded
-#     `RUNPATH=/usr/lib/firefox`, but we stage the artifact at
-#     /ms-playwright/firefox-{rev}/firefox/. Without prepending the bundle
-#     dir to LD_LIBRARY_PATH, the loader fails to resolve libmozsandbox.so
-#     and other peer .so files. Drop this half once the producer patches
-#     libxul's RUNPATH to `$ORIGIN` via patchelf (mirrors chromium artifact).
-RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
-            /ms-playwright/firefox-${FF_REV}/firefox/firefox.real \
- && printf '%s\n' \
-        '#!/bin/sh' \
-        'DIR="$(dirname "$0")"' \
-        'exec env LD_LIBRARY_PATH="$DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$DIR/firefox.real" --remote-debugging-port=0 "$@"' \
-  | sudo tee /ms-playwright/firefox-${FF_REV}/firefox/firefox >/dev/null \
- && sudo chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox
-
 # chromium-headless-shell — apk-extracted, self-contained via RPATH=$ORIGIN.
 # Smaller artifact than full chromium; deterministic timing for tests.
 COPY --from=chs-source /chrome-headless-shell-linux64 /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64
 RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV}
 
-# Runtime libs. Chromium artifact is self-contained (RPATH=$ORIGIN), but the
-# musl Firefox build dynamically links against system libs per aports'
-# mozconfig — install the runtime deps from aports' community/firefox
-# `depends=` minus things headless doesn't load.
-RUN sudo apk add --no-cache \
-        ca-certificates font-opensans ttf-freefont \
-        alsa-lib dbus-libs fontconfig glib gtk+3.0 harfbuzz icu-libs \
-        libdrm libevent libffi libjpeg-turbo libnotify libogg libtheora \
-        libvorbis libvpx libwebp libwebpdemux libxcomposite libxt mesa-gl \
-        nspr nss pipewire-libs libpulse \
+# Runtime: chromium-headless-shell artifact is self-contained (RPATH=$ORIGIN
+# bundles all its .so deps + system libs). Only ca-certificates + a font are
+# needed at runtime. pnpm install -g playwright pins the SDK to the same
+# version the producer used to derive the artifact revision.
+RUN sudo apk add --no-cache ca-certificates ttf-freefont \
  && pnpm install -g playwright@${PLAYWRIGHT_VERSION}

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -24,19 +24,19 @@ jobs:
 
 **Ubuntu vs Alpine**: pick **Ubuntu** for the full three-engine matrix
 (Chromium + Firefox + WebKit, Playwright-bundled browsers). Pick **Alpine**
-for a smaller image — Alpine now ships **musl-native Chromium + Firefox**
+for a smaller image — Alpine ships **musl-native chromium-headless-shell**
 via the [`playwright-alpine-browsers`](https://github.com/jclaveau/github-action-container-images/tree/main/playwright/alpine-browsers)
-producer image. WebKit on Alpine is still deferred (no PW-patched musl
-WebKit build exists yet); the alpine `playwright.config.ts` skips it
-automatically so `playwright test` (no `--project`) stays green.
+producer image. Firefox and WebKit on Alpine are deferred (see below); the
+alpine `playwright.config.ts` skips them automatically so `playwright test`
+(no `--project`) stays green.
 
 ## What it adds
 - **Playwright** (pinned by `PLAYWRIGHT_VERSION`) installed globally.
   - **Ubuntu**: the bundled browsers via `playwright install --with-deps --only-shell`;
     `PLAYWRIGHT_BROWSERS_PATH` is set.
-  - **Alpine**: musl-native **chromium-headless-shell** + **Firefox** staged
-    at PW SDK's auto-discovery cache path. Bundled-browser download is
-    skipped (see [musl-native browsers on Alpine](#musl-native-browsers-on-alpine)).
+  - **Alpine**: musl-native **chromium-headless-shell** staged at PW SDK's
+    auto-discovery cache path. Bundled-browser download is skipped (see
+    [musl-native browsers on Alpine](#musl-native-browsers-on-alpine)).
 
 ## musl-native browsers on Alpine
 
@@ -49,25 +49,25 @@ those compiled against **glibc** only — no musl artifacts.
 
 The `playwright-alpine-browsers` sub-project produces musl-native equivalents:
 
-- **Firefox**: built from PW's pinned Mozilla source with PW's `bootstrap.diff` +
-  `juggler/` overlay, on top of Alpine `aports/community/firefox`'s musl
-  patches. Same revision + browserVersion as `pnpm playwright install` would
-  have downloaded; mimicked exactly so PW SDK's auto-discovery picks it up
-  without an `executablePath` override.
 - **chromium-headless-shell**: extracted from Alpine community's
   `chromium-headless-shell` apk subpackage (aports already builds it for
   musl as part of `community/chromium`). Bundled `.so` deps + `RPATH=$ORIGIN`
   so the artifact is self-contained.
+- **Firefox**: built from PW's pinned Mozilla source with PW's `bootstrap.diff` +
+  `juggler/` overlay, on top of Alpine `aports/community/firefox`'s musl
+  patches. Producer publishes `ff-{revision}` but consumer wiring isn't
+  shipped here yet — cross-musl-version ABI mismatch (producer built on
+  alpine edge, this consumer base is 3.21) causes a segfault at XPCOM init.
+  Follow-up.
 - **WebKit**: not yet shipped — sub-project deferred. Drop in when ready.
 
 The producer publishes versioned + moving tags on both GHCR (CI-friendly,
 no Docker Hub pull-limit) and Docker Hub (external catalog):
 
 ```
-ghcr.io/jclaveau/playwright-alpine-browsers:ff-{revision}    jclaveau/...:ff-{revision}
-ghcr.io/jclaveau/playwright-alpine-browsers:ff-latest        jclaveau/...:ff-latest
 ghcr.io/jclaveau/playwright-alpine-browsers:chs-{revision}   jclaveau/...:chs-{revision}
 ghcr.io/jclaveau/playwright-alpine-browsers:chs-latest       jclaveau/...:chs-latest
+ghcr.io/jclaveau/playwright-alpine-browsers:ff-{revision}    jclaveau/...:ff-{revision}      (published, not wired here yet)
 ```
 
 Renovate keeps the COPY --from tags in `Dockerfile.alpine` synced with
@@ -86,26 +86,21 @@ Useful upstream references:
 - **Slim — no compiler.** Built on the slim [`pnpm`](../pnpm/README.md) layer. If your tests' deps
   compile native addons, use the **`…-playwright-gyp`** twin (the same layer built on
   [`pnpm-gyp`](../pnpm-gyp/README.md)); its tag carries a `-gyp` suffix.
-- The **heaviest** layer (browsers + runtime deps); Alpine grows vs the
-  previous Chromium-only build but gains a second working engine.
+- The **heaviest** layer (browsers + runtime deps); Alpine now switches from
+  the full Alpine Chromium apk to musl-native `chromium-headless-shell`
+  (deterministic timing for tests).
 - The version-pinned tag carries the Playwright minor (`…-pwX.Y`).
 - This directory also holds the **Playwright test project** (`tests/`,
   `playwright.config.ts`) that CI runs against the built image. The config
-  detects Alpine via `/etc/alpine-release` and runs `chromium + firefox`
-  there; other OSes run the full three-browser matrix.
+  detects Alpine via `/etc/alpine-release` and runs `chromium` only there;
+  other OSes run the full three-browser matrix.
 
 ## Required `playwright.config.ts` for Alpine consumers
 
-**Nothing required.** PW SDK auto-discovers the staged browsers via
+**Nothing required.** PW SDK auto-discovers the staged browser via
 `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` set in the image. Your own
 `playwright.config.ts` can use vanilla project definitions; no
-`executablePath` override needed. Just be aware: WebKit isn't shipped on
-Alpine yet — either omit the WebKit project (we do this in the in-repo
-`playwright.config.ts`) or pass `--project=chromium,firefox` to filter at
+`executablePath` override needed. Just be aware: Firefox and WebKit aren't
+shipped on Alpine yet — either omit those projects (we do this in the
+in-repo `playwright.config.ts`) or pass `--project=chromium` to filter at
 test invocation time.
-
-For Firefox specifically, the alpine image includes a 4-line shim that
-prepends `--remote-debugging-port=0` to every `firefox.launch()` — works
-around a Juggler-activation quirk in our musl FF build (not musl-specific;
-same dormant behavior on glibc when building from PW's patches outside
-their CDN pipeline). Transparent to your tests.

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -22,78 +22,90 @@ jobs:
       - run: pnpm exec playwright test
 ```
 
-**Ubuntu vs Alpine**: pick **Ubuntu** for the full three-engine matrix (Chromium + Firefox +
-WebKit, Playwright-bundled browsers). Pick **Alpine** for a smaller image when **Chromium-only**
-coverage is enough — see [Why Alpine is Chromium-only](#why-alpine-is-chromium-only). Alpine
-consumers also need the [`playwright.config.ts` snippet below](#required-playwrightconfigts-for-alpine-consumers).
+**Ubuntu vs Alpine**: pick **Ubuntu** for the full three-engine matrix
+(Chromium + Firefox + WebKit, Playwright-bundled browsers). Pick **Alpine**
+for a smaller image — Alpine now ships **musl-native Chromium + Firefox**
+via the [`playwright-alpine-browsers`](https://github.com/jclaveau/github-action-container-images/tree/main/playwright/alpine-browsers)
+producer image. WebKit on Alpine is still deferred (no PW-patched musl
+WebKit build exists yet); the alpine `playwright.config.ts` skips it
+automatically so `playwright test` (no `--project`) stays green.
 
 ## What it adds
 - **Playwright** (pinned by `PLAYWRIGHT_VERSION`) installed globally.
   - **Ubuntu**: the bundled browsers via `playwright install --with-deps --only-shell`;
     `PLAYWRIGHT_BROWSERS_PATH` is set.
-  - **Alpine**: **Chromium-only** via the system `chromium` package at `/usr/bin/chromium-browser`;
-    the bundled-browser download is skipped (see
-    [Why Alpine is Chromium-only](#why-alpine-is-chromium-only)).
+  - **Alpine**: musl-native **chromium-headless-shell** + **Firefox** staged
+    at PW SDK's auto-discovery cache path. Bundled-browser download is
+    skipped (see [musl-native browsers on Alpine](#musl-native-browsers-on-alpine)).
 
-## Why Alpine is Chromium-only
+## musl-native browsers on Alpine
 
-Playwright doesn't drive off-the-shelf browsers — it builds and pins **patched** ones:
-[Firefox](https://github.com/microsoft/playwright/tree/main/browser_patches/firefox) carries the
-*Juggler* automation protocol and [WebKit](https://github.com/microsoft/playwright/tree/main/browser_patches/webkit)
-is a patched build. Those are compiled against **glibc** and there are **no musl/Alpine builds**, so they
-can't load on Alpine — and `playwright install --with-deps` runs `apt`, which doesn't exist there either.
+Playwright doesn't drive off-the-shelf browsers — it builds and pins
+**patched** ones. [Firefox](https://github.com/microsoft/playwright/tree/main/browser_patches/firefox)
+carries the *Juggler* automation protocol, [WebKit](https://github.com/microsoft/playwright/tree/main/browser_patches/webkit)
+is a patched build, and `chromium-headless-shell` is a deterministic
+headless variant Google ships via Chrome-for-Testing. Upstream PW publishes
+those compiled against **glibc** only — no musl artifacts.
 
-Chromium is the exception: Playwright drives it over the stock **CDP** protocol, so it can point at the
-distro's musl-native `chromium` package (`apk add chromium`) via `executablePath` — no patched build
-needed. Hence Alpine tops out at Chromium.
+The `playwright-alpine-browsers` sub-project produces musl-native equivalents:
 
-Track whether this ever changes:
-- [Playwright system requirements](https://playwright.dev/docs/intro#system-requirements) — the official
-  supported-OS list. Today it's Debian / Ubuntu only; Alpine appearing here would mean musl builds exist.
-- [microsoft/playwright#1986](https://github.com/microsoft/playwright/issues/1986) — the canonical
-  "Alpine Linux Support" thread. A maintainer confirms there are no plans, and points at the remote
-  `mcr.microsoft.com/playwright` browser container (connect over WebSocket) as the only cross-distro path.
+- **Firefox**: built from PW's pinned Mozilla source with PW's `bootstrap.diff` +
+  `juggler/` overlay, on top of Alpine `aports/community/firefox`'s musl
+  patches. Same revision + browserVersion as `pnpm playwright install` would
+  have downloaded; mimicked exactly so PW SDK's auto-discovery picks it up
+  without an `executablePath` override.
+- **chromium-headless-shell**: extracted from Alpine community's
+  `chromium-headless-shell` apk subpackage (aports already builds it for
+  musl as part of `community/chromium`). Bundled `.so` deps + `RPATH=$ORIGIN`
+  so the artifact is self-contained.
+- **WebKit**: not yet shipped — sub-project deferred. Drop in when ready.
+
+The producer publishes versioned + moving tags on both GHCR (CI-friendly,
+no Docker Hub pull-limit) and Docker Hub (external catalog):
+
+```
+ghcr.io/jclaveau/playwright-alpine-browsers:ff-{revision}    jclaveau/...:ff-{revision}
+ghcr.io/jclaveau/playwright-alpine-browsers:ff-latest        jclaveau/...:ff-latest
+ghcr.io/jclaveau/playwright-alpine-browsers:chs-{revision}   jclaveau/...:chs-{revision}
+ghcr.io/jclaveau/playwright-alpine-browsers:chs-latest       jclaveau/...:chs-latest
+```
+
+Renovate keeps the COPY --from tags in `Dockerfile.alpine` synced with
+`playwright@${PLAYWRIGHT_VERSION}`'s pinned revisions.
+
+Useful upstream references:
+- [Playwright system requirements](https://playwright.dev/docs/intro#system-requirements) —
+  the official supported-OS list. Today Alpine doesn't appear there; this
+  image is the wedge that fills the gap.
+- [microsoft/playwright#1986](https://github.com/microsoft/playwright/issues/1986) —
+  canonical "Alpine Linux Support" thread; PW maintainers state no plans for
+  official musl builds.
 
 ## What it implies
 - Built for **both modes and both OSes**: `ubuntu-dood-playwright`, `alpine-dind-playwright`, etc.
 - **Slim — no compiler.** Built on the slim [`pnpm`](../pnpm/README.md) layer. If your tests' deps
   compile native addons, use the **`…-playwright-gyp`** twin (the same layer built on
   [`pnpm-gyp`](../pnpm-gyp/README.md)); its tag carries a `-gyp` suffix.
-- The **heaviest** layer (Ubuntu bundles browsers; Alpine pulls system Chromium + fonts).
+- The **heaviest** layer (browsers + runtime deps); Alpine grows vs the
+  previous Chromium-only build but gains a second working engine.
 - The version-pinned tag carries the Playwright minor (`…-pwX.Y`).
-- This directory also holds the **Playwright test project** (`tests/`, `playwright.config.ts`) that CI
-  runs against the built image. The config auto-detects the system Chromium at
-  `/usr/bin/chromium-browser` (Alpine) and runs Chromium-only when present.
+- This directory also holds the **Playwright test project** (`tests/`,
+  `playwright.config.ts`) that CI runs against the built image. The config
+  detects Alpine via `/etc/alpine-release` and runs `chromium + firefox`
+  there; other OSes run the full three-browser matrix.
 
 ## Required `playwright.config.ts` for Alpine consumers
 
-Playwright's `executablePath` (in `launch()` or project `launchOptions`) must point at the system
-Chromium installed by `alpine-…-playwright` at `/usr/bin/chromium-browser`. Vanilla Playwright won't
-discover it on its own — `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` is set in the image so no bundled
-browser is fetched at `pnpm install` time, and Playwright doesn't probe `$PATH` for system browsers.
+**Nothing required.** PW SDK auto-discovers the staged browsers via
+`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` set in the image. Your own
+`playwright.config.ts` can use vanilla project definitions; no
+`executablePath` override needed. Just be aware: WebKit isn't shipped on
+Alpine yet — either omit the WebKit project (we do this in the in-repo
+`playwright.config.ts`) or pass `--project=chromium,firefox` to filter at
+test invocation time.
 
-Required snippet (or equivalent) when you use `alpine-…-playwright`:
-
-```ts
-import { defineConfig, devices } from '@playwright/test';
-
-// jclaveau/alpine-…-playwright: Playwright cannot ship its bundled glibc Chromium on musl,
-// so the image provides system chromium at /usr/bin/chromium-browser. Point Playwright at it.
-export default defineConfig({
-  projects: [{
-    name: 'chromium',
-    use: { ...devices['Desktop Chrome'],
-           launchOptions: { executablePath: '/usr/bin/chromium-browser' } },
-  }],
-});
-```
-
-Without this, the alpine image's vanilla-config consumer gets `Executable doesn't exist at
-/home/runner/.cache/ms-playwright/chromium-…/headless_shell` because
-`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` was honored at install time. Ubuntu images don't need this
-override — Playwright finds its bundled browsers via `PLAYWRIGHT_BROWSERS_PATH`.
-
-(`test-playwright-vanilla-config` in `.github/workflows/test-and-publish.yml` asserts both halves:
-the failure mode with a stock `npx playwright init` config, and a passing run with the snippet
-above — so we'll know the day Playwright upstream changes its resolution semantics or starts
-discovering `/usr/bin/chromium-browser` directly.)
+For Firefox specifically, the alpine image includes a 4-line shim that
+prepends `--remote-debugging-port=0` to every `firefox.launch()` — works
+around a Juggler-activation quirk in our musl FF build (not musl-specific;
+same dormant behavior on glibc when building from PW's patches outside
+their CDN pipeline). Transparent to your tests.

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -8,8 +8,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "1.50.1",
+    "@playwright/test": "1.60.0",
     "@types/node": "^24.9.1",
-    "playwright": "1.50.1"
+    "playwright": "1.60.0"
   }
 }

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -13,18 +13,18 @@ import { existsSync } from 'node:fs';
  * See https://playwright.dev/docs/test-configuration.
  */
 
-// On Alpine/musl, Playwright's bundled browsers don't run, so we use the system Chromium installed
-// at /usr/bin/chromium-browser by the alpine-…-playwright Dockerfile (`apk add chromium`). Chromium
-// is the only option (no official Firefox/WebKit musl builds). Other OSes get the full bundled
-// browser matrix below.
-const systemChromium = existsSync('/usr/bin/chromium-browser') ? '/usr/bin/chromium-browser' : undefined;
+// On the Alpine flavor, the alpine-...-playwright Dockerfile COPYs musl-native
+// chromium-headless-shell + Firefox from the `playwright-alpine-browsers`
+// producer image and stages them at PW SDK's auto-discovery cache path. No
+// executablePath override needed. WebKit is not shipped yet (sub-project
+// deferred), so we skip it on alpine to keep `playwright test` (no
+// --project) green. Drop the alpine branch once the WebKit producer lands.
+const isAlpine = existsSync('/etc/alpine-release');
 
-const projects = systemChromium
+const projects = isAlpine
   ? [
-      {
-        name: 'chromium',
-        use: { ...devices['Desktop Chrome'], launchOptions: { executablePath: systemChromium } },
-      },
+      { name: 'chromium', use: { ...devices['Desktop Chrome']  } },
+      { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
     ]
   : [
       {
@@ -84,7 +84,8 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
-  /* Configure projects for major browsers (Chromium-only on Alpine; see `projects` above) */
+  /* Configure projects for major browsers. On Alpine: chromium + firefox
+     only (WebKit deferred). See `projects` block above for rationale. */
   projects,
 
   /* Run your local dev server before starting the tests */

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -13,18 +13,19 @@ import { existsSync } from 'node:fs';
  * See https://playwright.dev/docs/test-configuration.
  */
 
-// On the Alpine flavor, the alpine-...-playwright Dockerfile COPYs musl-native
-// chromium-headless-shell + Firefox from the `playwright-alpine-browsers`
-// producer image and stages them at PW SDK's auto-discovery cache path. No
-// executablePath override needed. WebKit is not shipped yet (sub-project
-// deferred), so we skip it on alpine to keep `playwright test` (no
-// --project) green. Drop the alpine branch once the WebKit producer lands.
+// On the Alpine flavor, the alpine-...-playwright Dockerfile COPYs the
+// musl-native `chromium-headless-shell` from the `playwright-alpine-browsers`
+// producer image (self-contained via RPATH=$ORIGIN) and stages it at PW SDK's
+// auto-discovery cache path. No executablePath override needed. Firefox and
+// WebKit are not shipped yet on alpine (FF segfaults under cross-musl-version
+// ABI when the producer's edge-built artifact runs on the alpine 3.21 base —
+// follow-up; WebKit sub-project deferred). Drop the alpine branch once both
+// producers land.
 const isAlpine = existsSync('/etc/alpine-release');
 
 const projects = isAlpine
   ? [
-      { name: 'chromium', use: { ...devices['Desktop Chrome']  } },
-      { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
+      { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     ]
   : [
       {

--- a/playwright/pnpm-lock.yaml
+++ b/playwright/pnpm-lock.yaml
@@ -9,19 +9,19 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: 1.50.1
-        version: 1.50.1
+        specifier: 1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^24.9.1
         version: 24.9.1
       playwright:
-        specifier: 1.50.1
-        version: 1.50.1
+        specifier: 1.60.0
+        version: 1.60.0
 
 packages:
 
-  '@playwright/test@1.50.1':
-    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -33,13 +33,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  playwright-core@1.50.1:
-    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.50.1:
-    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -48,9 +48,9 @@ packages:
 
 snapshots:
 
-  '@playwright/test@1.50.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.50.1
+      playwright: 1.60.0
 
   '@types/node@24.9.1':
     dependencies:
@@ -59,11 +59,11 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  playwright-core@1.50.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.50.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.50.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Why

The `playwright-alpine` image had a known retrocompat hole: the Chromium it shipped was Alpine's full distro Chromium apk, with real GPU process + utility processes + non-deterministic frame timing. The cascading-select test I hit broke specifically because of that timing — full Chromium isn't what `playwright install` would normally give you.

PW SDK actually expects `chrome-headless-shell` (what `playwright install --only-shell` downloads): smaller, deterministic timing, no UI process tree. Producer PR #17 (merged) builds a musl-native `chrome-headless-shell` from Alpine community/chromium's apk subpackage with all `.so` deps bundled via ldd-walk + `RPATH=$ORIGIN`. This PR wires it into `playwright/Dockerfile.alpine` via PW SDK's auto-discovery cache path.

## What

- `playwright/Dockerfile.alpine`: drops `apk add chromium` + the `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` ARG. COPYs `chromium-headless-shell` from the producer image into `/ms-playwright/chromium_headless_shell-${CHS_REV}/...`. `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` + `PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24` so PW SDK finds the staged binary and skips the "musl not supported" warning safely.
- `playwright/Dockerfile.alpine` uses BuildKit's named-stage aliasing (`FROM ghcr.io/...:chs-${CHS_REV} AS chs-source`) since BuildKit doesn't support ARG expansion in `COPY --from=` URLs.
- `playwright/playwright.config.ts`: alpine probe via `existsSync('/etc/alpine-release')` runs `chromium`-only on alpine; other OSes run the full 3-browser matrix unchanged.
- `playwright/package.json` + `pnpm-lock.yaml`: PW bump 1.50.1 → 1.60.0 so the SDK's bundled `browsers.json` revision matches what the producer published (`chs-1223`).
- `playwright/README.md`: rewritten "Why Alpine is Chromium-only" → "musl-native chromium-headless-shell on Alpine" with producer-image references and a documented FF/WebKit follow-up.
- `.github/workflows/test-and-publish.yml`: the alpine vanilla-config regression test inverted — it used to assert vanilla config FAILS (pinning the old `/usr/bin/chromium-browser` workaround); now it asserts vanilla config PASSES via auto-discovery (the new contract).

## Open questions for the reviewer

- **Image-size delta**: rough estimate going from full Alpine chromium apk to the chromium-headless-shell artifact + bundled .so + retained chromium-runtime apks. Could be smaller, could be similar — bench not re-run in this PR. Worth a follow-up to measure?
- **Renovate**: producer image tag (`chs-1223`) is hand-pinned in the Dockerfile ARG. A custom Renovate manager would track it against the producer's published tag list — not in this PR. Worth a follow-up?
- **Chromium runtime apks**: kept `dbus-libs fontconfig glib harfbuzz libdrm libffi libjpeg-turbo libwebp libwebpdemux libxcomposite mesa-gl nspr nss` — Chromium dlopen's some of these even though the .so is bundled (fontconfig configs at /etc/fonts, NSS PKCS11 modules, etc.). I trimmed audio/UI (alsa/pipewire/libpulse/gtk+3.0/libnotify) since headless doesn't touch them. Is this scope right or should I trim more aggressively after measuring impact?

## Retrocompat flag

- The Alpine image's Chromium switches from full Chromium to `chrome-headless-shell`. Behavior delta:
  - **Pro**: deterministic timer + frame scheduling (fixes the cascading-select test).
  - **Con**: no real GPU process, no utility processes — if a downstream test was relying on full-Chromium specifics, it'll need adjustment.
- Vanilla `playwright.config.ts` (no `executablePath` override) now WORKS on alpine. The previous documented snippet (`launchOptions: { executablePath: '/usr/bin/chromium-browser' }`) no longer works because we dropped that file; if a downstream consumer copy-pasted that snippet, they'll need to drop it.

## Out of scope (explicit follow-ups)

- **Firefox on alpine**: producer publishes `ff-{rev}` (#40 landed the ldd-walk + RPATH=$ORIGIN bundle), but the consumer wiring isn't shipped here. Reason: cross-musl-version ABI mismatch — producer artifact is built on alpine **edge** (musl 1.2.5-r21), consumer base is alpine **3.21.7** (musl 1.2.5-r11). FF segfaults at XPCOM init with the bundled libstdc++/libgcc_s/ld-musl from edge running against 3.21's musl runtime. `firefox --version` works (minimal init), `--headless -profile` crashes. Two paths for the follow-up: (a) tune the producer's bundle to exclude universal libs (musl libc, libstdc++, libgcc_s) and let them resolve from the runtime base; (b) align the producer and consumer alpine versions. Tried bumping consumer to alpine edge in this PR — blocked by GHA's BuildKit seccomp rejecting `renameat2` from edge's newer coreutils, reverted (commit `f469279`).
- **WebKit on alpine**: deferred sub-project. PW patches exist but no aports recipe matches.
- **ARM64**: amd64 only in this PR; aarch64 across the producer chain is a follow-up.
- **Bench update**: dropping the `alpine-*` exclusion in `.github/workflows/benchmark-playwright.yml` for the new `chromium-firefox` mode. Follow-up once FF on alpine ships.

## Depends on

Producer PRs #17 + #40 merged on main. Producer publishes `chs-1223` to GHCR + Docker Hub.

Assisted-by: Claude:claude-opus-4-7
