### PR TITLE
firefox: bundle .so deps via ldd-walk + RPATH=$ORIGIN

### DIFF
--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -475,3 +475,57 @@ echo "===== Staging dist to /work/firefox-dist ====="
 mkdir -p /work/firefox-dist
 cp -aL "$DIST"/. /work/firefox-dist/ 2>/dev/null || cp -a "$DIST"/. /work/firefox-dist/
 echo "Staged: $(du -sh /work/firefox-dist | cut -f1)"
+
+# Bundle transitive .so deps via ldd-walk + RPATH=$ORIGIN. Aports' Firefox
+# LDFLAGS hardcodes RUNPATH=/usr/lib/firefox; the artifact ships at any path
+# the consumer chooses (/ms-playwright/firefox-{rev}/firefox in PW SDK
+# auto-discovery), so the loader can't find peer/system libs. Mirror the
+# chromium-headless-shell treatment: bundle system .so deps into the dist
+# tree and patchelf RPATH=$ORIGIN on every binary + .so. Result: a fully
+# self-contained artifact that works on any musl base regardless of ICU/
+# NSPR/NSS/libstdc++ version drift.
+echo "===== Bundling .so deps + patchelf RPATH=\$ORIGIN ====="
+DST=/work/firefox-dist
+FF_BINS="$DST/firefox $DST/firefox-bin $DST/glxtest $DST/vaapitest $DST/pingsender"
+
+# Walk ldd on a target, copy system .so deps into $DST (top level only —
+# nested gmp-clearkey/ etc. dlopen explicitly and inherit firefox's RPATH).
+ldd_walk() {
+  local target="$1"
+  [ -e "$target" ] || return 0
+  for so in $(ldd "$target" 2>/dev/null | awk '{print $3}' | grep '^/' || true); do
+    [ -f "$so" ] && [ ! -f "$DST/$(basename "$so")" ] && cp -aL "$so" "$DST"/ || true
+  done
+}
+
+# Pass 1: walk binaries + already-bundled .so files.
+for t in $FF_BINS; do ldd_walk "$t"; done
+for so in "$DST"/*.so*; do [ -L "$so" ] || ldd_walk "$so"; done
+# Pass 2: deps-of-deps for second-order resolution (libicui18n -> libicuuc, etc.)
+for so in "$DST"/*.so*; do [ -L "$so" ] || ldd_walk "$so"; done
+# Pass 3: rare third-order (libstdc++ -> libgcc_s, etc.)
+for so in "$DST"/*.so*; do [ -L "$so" ] || ldd_walk "$so"; done
+
+# Patchelf RPATH=$ORIGIN on every binary + top-level .so. The loader uses
+# RPATH of the LOADING module, so libxul.so needs $ORIGIN to find peer libs
+# in the same dir.
+for t in $FF_BINS; do
+  [ -f "$t" ] && patchelf --set-rpath '$ORIGIN' "$t" 2>/dev/null || true
+done
+for so in "$DST"/*.so*; do
+  [ -L "$so" ] && continue
+  patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
+done
+
+# Sanity check: no "not found" in libxul ldd. Fail loud at producer time,
+# not silently at consumer runtime. (firefox-bin is small; libxul.so is the
+# fat one and most likely to surface missing deps.)
+missing=$(ldd "$DST/libxul.so" 2>/dev/null | grep 'not found' || true)
+if [ -n "$missing" ]; then
+  echo "ERROR: libxul.so still has unresolved deps after bundle:" >&2
+  echo "$missing" >&2
+  echo "---firefox binary ldd:" >&2
+  ldd "$DST/firefox" 2>&1 | head -30 >&2
+  exit 1
+fi
+echo "===== Self-contained artifact: $(du -sh "$DST" | cut -f1) ====="


### PR DESCRIPTION
## Why

The FF producer artifact wasn't self-contained. Consumer-side (PR #39) hit:

```
XPCOMGlueLoad error for file /ms-playwright/firefox-1522/firefox/libxul.so:
Error loading shared library libicui18n.so.78: No such file or directory
Couldn't load XPCOM.
```

Aports' FF LDFLAGS hardcodes `RUNPATH=/usr/lib/firefox` and relies on system `icu-libs`, `nspr`, `nss`, etc. When the artifact ships at a different path AND the consumer's alpine base is a different version (3.21 ICU 74 vs producer's edge ICU 78), the loader fails.

Tried band-aids in PR #39 first:
- `LD_LIBRARY_PATH="$DIR"` in the FF shim → resolved bundle peer libs (libmozsandbox.so) but not system libs (libicui18n.so.78 — missing on alpine 3.21).
- Bumping consumer base alpine 3.21 → edge → blocked by GHA seccomp profile rejecting `renameat2` from edge's newer coreutils.

The proper fix is producer-side: make the artifact match how chromium-headless-shell already ships (commit 6395165). Self-contained, no consumer-side LD path workarounds, future-proof against ABI drift.

## What

`playwright/alpine-browsers/firefox/scripts/apply-and-build.sh` gets a new bundle step after the dist staging:

1. **ldd-walk** the FF binaries (`firefox`, `firefox-bin`, `glxtest`, `vaapitest`, `pingsender`) + already-bundled `.so` files; copy each system `.so` dep into the dist tree. 3 passes for transitive resolution (libxul → libicui18n → libicuuc → libstdc++ → libgcc_s).
2. **patchelf `--set-rpath '\$ORIGIN'`** on every binary + top-level `.so` so the loader looks in the bundle dir first. Nested `gmp-clearkey/0.1/libclearkey.so` is unchanged (dlopen'd explicitly by FF, inherits firefox's RPATH).
3. **Fail-loud sanity check**: `ldd \$DST/libxul.so | grep 'not found'` exits non-zero only when a missing dep slipped through.

Mirrors chromium-headless-shell architecture exactly. \`patchelf\` is already in the builder image.

## Open questions for the reviewer

- **Size delta**: estimated +30-80 MB (libstdc++, libicu*, libnss*, libgtk-3*). The plan mentioned ~2× the chromium-only alpine; this bundle pushes the FF half slightly higher. Acceptable trade for the drop-in promise, or worth trimming (e.g. exclude debug syms, locale data)?
- **Three ldd-walk passes**: could be a `while`-loop until idempotent, but three fixed passes is what chromium uses. Match for consistency or improve?
- **Bundling system libs**: the consumer's `apk add` runtime libs list (fontconfig, gtk+3.0, etc.) may become partially redundant for FF. Will untangle in PR #39 (drop the FF-specific apks once this lands).

## Retrocompat

- `ff-1522` tag's digest changes (artifact tree gets ~30-80 MB heavier, RPATH on binaries/libs flips from `/usr/lib/firefox` to `\$ORIGIN`).
- Any external consumer that staged the producer artifact under `/usr/lib/firefox/` and relied on the system providing matching ICU/NSPR will see a behavioral change: their bundled system libs now shadow each other via \$ORIGIN. Net safer (the producer-bundled versions match what FF was linked against).
- PW SDK consumers (the intended audience) see no change in behavior — FF launches and runs identically.

## Out of scope

- Replicate for the chromium-headless-shell-from-source path (already disabled in workflow per the apk fast-path pivot).
- Strip locale .so / debug sym from bundled deps (optimization, not correctness).
- Update README to document the self-contained artifact shape (text-only, separate doc PR).

## Depends on

Nothing. Lands on main, producer workflow rebuilds and republishes `ff-1522` (~2-3h cold, ~5-10min if obj/ cache survives). Consumer PR #39 then re-runs and FF should pass without any consumer-side changes (the LD_LIBRARY_PATH shim becomes redundant but harmless).

Assisted-by: Claude:claude-opus-4-7