### PR TITLE
feat(on-demand): PW-version-aware CHS_REV alignment + drift catalog

### DIFF
--- a/.github/workflows/on-demand-build.yml
+++ b/.github/workflows/on-demand-build.yml
@@ -259,6 +259,50 @@ jobs:
     if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     steps:
+      - id: detect-chromium-drift
+        # Alpine playwright variants COPY the chromium-headless-shell artifact
+        # from the producer. If the producer's edge-current chromium pkgver
+        # didn't match the PW pin requested by this issue, it baked a
+        # /chrome-headless-shell-linux64/.version-drift-warning file inside
+        # the artifact. PW SDK is silent on this at launch (path-name match
+        # is enough); the only signal is that file. Surface it in the issue
+        # comment so requesters who need exact chromium-version semantics
+        # see the warning before they consume the image.
+        if: needs.build.result == 'success' && needs.prepare.outputs.chs_rev != ''
+        env:
+          TAGS: ${{ needs.build.outputs.tags }}
+          CHS_REV: ${{ needs.prepare.outputs.chs_rev }}
+        run: |
+          set -euo pipefail
+          # Pick the first alpine playwright tag from the aggregator's output.
+          # Any variant (dood/dind, slim/gyp) has the same chromium artifact,
+          # so the first match is representative.
+          TAG=$(echo "$TAGS" | grep -E 'alpine-(dood|dind)-playwright' | head -1 || true)
+          if [ -z "$TAG" ]; then
+            echo "No alpine playwright tag in the build outputs (image variant not selected?) — skip drift check"
+            echo "warning=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Checking $TAG for chromium drift warning"
+          # Anonymous Docker Hub pull (one-off; well within free rate limit).
+          # Returns the warning file contents to stdout if present; empty otherwise.
+          docker pull -q "$TAG" >/dev/null
+          WARN=$(docker run --rm --entrypoint=/bin/sh "$TAG" -c \
+            "cat /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64/.version-drift-warning 2>/dev/null" \
+            || true)
+          if [ -n "$WARN" ]; then
+            echo "drift detected:"
+            echo "$WARN"
+            {
+              echo 'warning<<DRIFT_EOF'
+              echo "$WARN"
+              echo 'DRIFT_EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "no drift warning baked"
+            echo "warning=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Comment success + close
         if: needs.build.result == 'success'
         env:
@@ -267,16 +311,35 @@ jobs:
           # strings, emitted by test-and-publish.yml's aggregate-tags job.
           # Empty when the aggregator collected no artifacts (defensive).
           TAGS: ${{ needs.build.outputs.tags }}
+          DRIFT: ${{ steps.detect-chromium-drift.outputs.warning }}
         run: |
           set -euo pipefail
+          : > /tmp/comment.md
+          # Prepend the drift warning (if any) so requesters see it above the
+          # tag list. Keeps the success status intact — the image WAS published
+          # successfully; the drift is an advisory, not a failure.
+          if [ -n "$DRIFT" ]; then
+            {
+              echo ':warning: **Chromium version drift in the alpine variants**'
+              echo
+              echo '```'
+              echo "$DRIFT"
+              echo '```'
+              echo
+              echo 'PW SDK will still launch the binary (path-name match), but tests depending on chromium-version-specific behaviors may behave differently.'
+              echo
+              echo '---'
+              echo
+            } >> /tmp/comment.md
+          fi
           if [ -n "$TAGS" ]; then
             {
               echo ':white_check_mark: Build complete. Published:'
               echo
               echo "$TAGS" | sed 's/^/- `/; s/$/`/'
-            } > /tmp/comment.md
+            } >> /tmp/comment.md
           else
-            echo ':white_check_mark: Build complete. New pinned tag(s) live under https://hub.docker.com/u/jclaveau — no per-tag list was emitted by the run.' > /tmp/comment.md
+            echo ':white_check_mark: Build complete. New pinned tag(s) live under https://hub.docker.com/u/jclaveau — no per-tag list was emitted by the run.' >> /tmp/comment.md
           fi
           gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/comment.md
           gh issue edit "${{ github.event.issue.number }}" --remove-label building --add-label published

--- a/.github/workflows/on-demand-build.yml
+++ b/.github/workflows/on-demand-build.yml
@@ -83,6 +83,7 @@ jobs:
       node_version: ${{ steps.parse.outputs.node_version }}
       pnpm_version: ${{ steps.parse.outputs.pnpm_version }}
       pw_version:   ${{ steps.parse.outputs.pw_version }}
+      chs_rev:      ${{ steps.derive-chs.outputs.chs_rev }}
     steps:
       - id: ensure-labels
         # `gh issue edit --add-label` errors if the label doesn't exist in the
@@ -153,6 +154,48 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Parsed: os='$OS' os_version='$OS_VERSION' image='$IMAGE' flavor='$FLAVOR' node='$NODE' pnpm='$PNPM' pw='$PW'"
 
+      - id: derive-chs
+        # Alpine consumer Dockerfile's `ARG CHS_REV` controls which producer
+        # tag (chs-<rev>) the playwright variants COPY --from. Default is the
+        # current pin baked into Dockerfile.alpine. When the requester pins a
+        # PW version that differs, derive the matching chs revision from PW's
+        # browsers.json so the consumer image stages the right artifact path.
+        #
+        # No PW version requested → empty output → test-and-publish keeps the
+        # Dockerfile.alpine default (no behavior change for the primary flow).
+        #
+        # Pre-flight: assert the producer has actually published chs-<rev>.
+        # The producer is push-on-main or workflow_dispatch — historical pins
+        # only exist if someone dispatched the producer for that PW version
+        # while alpine:edge still shipped that chromium (catalog accumulation;
+        # see playwright-alpine-browsers.yml). Missing tag → fail-loud with
+        # guidance, no wasted ~10 min consumer build.
+        env:
+          PW: ${{ steps.parse.outputs.pw_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PW" ]; then
+            echo "chs_rev=" >> "$GITHUB_OUTPUT"
+            echo "no PW version requested → consumer keeps Dockerfile.alpine default CHS_REV"
+            exit 0
+          fi
+          CHS_REV=$(curl -fsSL "https://unpkg.com/playwright-core@${PW}/browsers.json" \
+            | jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .revision')
+          if [ -z "$CHS_REV" ] || [ "$CHS_REV" = "null" ]; then
+            echo "::error::Cannot resolve chromium-headless-shell revision for PW $PW. browsers.json may not list it (very old PW?). Bump the request to a supported PW version."
+            exit 1
+          fi
+          echo "PW $PW → chromium-headless-shell rev $CHS_REV"
+          echo "chs_rev=$CHS_REV" >> "$GITHUB_OUTPUT"
+          # Pre-flight: tag must already exist on GHCR. The producer publishes
+          # one tag per dispatched PW version; if it's not there, the
+          # alpine-playwright consumer build would fail at COPY time.
+          if ! docker manifest inspect "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV}" >/dev/null 2>&1; then
+            echo "::error::Producer tag ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} not published. Dispatch playwright-alpine-browsers.yml with build_chromium_headless_shell=true and pw_version=${PW} first, then reopen this issue."
+            exit 1
+          fi
+          echo "pre-flight: chs-${CHS_REV} confirmed on GHCR"
+
       # Earlier revisions had a 3/24h quota step here and an existing-tag
       # precheck before that. Both gone: rate-limiting is now serial-execution
       # via the workflow-level `concurrency` group (see file header), and the
@@ -204,6 +247,7 @@ jobs:
       node_version:   ${{ needs.prepare.outputs.node_version }}
       pnpm_version:   ${{ needs.prepare.outputs.pnpm_version }}
       pw_version:     ${{ needs.prepare.outputs.pw_version }}
+      chs_rev:        ${{ needs.prepare.outputs.chs_rev }}
       only_os:        ${{ needs.prepare.outputs.os }}
       only_image:     ${{ needs.prepare.outputs.image }}
       only_flavor:    ${{ needs.prepare.outputs.flavor }}

--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -17,8 +17,30 @@ on:
       - 'playwright/alpine-browsers/**'
       - '!playwright/alpine-browsers/Dockerfile.glibc-debug'
       - '.github/workflows/playwright-alpine-browsers.yml'
+  # Catalog accumulator: weekly cron grabs whatever alpine:edge currently
+  # ships as chromium-headless-shell and publishes it as chs-${rev} where
+  # ${rev} is derived from versions.env's PW_VERSION default. Without this,
+  # once alpine:edge moves to a newer chromium pkgver, the old chs-${rev}
+  # tag stays as the last successful publish but no NEW tags accumulate
+  # for in-between PW versions. The cron locks in each alpine:edge state
+  # against the matching PW pin while the apk is still pullable. Sundays
+  # at 06:00 UTC — outside typical PR / on-demand traffic windows.
+  schedule:
+    - cron: '0 6 * * 0'
   workflow_dispatch:
     inputs:
+      # PW version override. When set, the producer derives CHS_REV / FF_REV
+      # from this version's `playwright-core@${pw_version}/browsers.json`
+      # instead of the versions.env default. The resulting tag (chs-${REV})
+      # is named after THAT PW pin even if alpine:edge currently ships a
+      # different chromium pkgver — drift detection in the build script
+      # bakes a warning file into the artifact, surfaced at consumer image
+      # build time. Empty = use versions.env's PW_VERSION (default flow).
+      pw_version:
+        description: 'PW version to derive CHS_REV/FF_REV from (empty = versions.env default)'
+        required: false
+        default: ''
+        type: string
       # Which browser(s) to build. Default firefox=false, chromium=true: the
       # FF artifact is already green + cached, and chromium is the active
       # diagnostic frontier — most manual dispatches want chromium only.
@@ -95,6 +117,13 @@ permissions:
   packages: write
   actions: write   # so the cancel-on-fail step can call /actions/runs/<id>/cancel
 
+env:
+  # Surface workflow_dispatch's pw_version input to every step's PW_VERSION
+  # resolution. The `pins` steps source versions.env then check this — if
+  # non-empty, it wins. Empty on push/PR events; set only when the user
+  # explicitly picks a non-default PW pin via workflow_dispatch.
+  PW_VERSION_OVERRIDE: ${{ inputs.pw_version || '' }}
+
 jobs:
   build:
     # FF gate. Runs on:
@@ -121,6 +150,13 @@ jobs:
       - id: pins
         run: |
           set -a; . playwright/alpine-browsers/versions.env; set +a
+          # workflow_dispatch override: if `pw_version` input was set, it wins
+          # over versions.env's PW_VERSION default. Powers the on-demand path
+          # where a different PW pin (e.g. 1.59.1) needs its own chs/ff rev.
+          if [ -n "${PW_VERSION_OVERRIDE:-}" ]; then
+            echo "pin override: PW_VERSION=$PW_VERSION → $PW_VERSION_OVERRIDE (workflow_dispatch input)"
+            PW_VERSION="$PW_VERSION_OVERRIDE"
+          fi
           echo "pw_version=$PW_VERSION" >> "$GITHUB_OUTPUT"
           # Resolve PW's pinned firefox revision + version from the matching
           # playwright-core npm package's browsers.json. Single source of truth.
@@ -410,8 +446,16 @@ jobs:
   promote-chromium-headless-shell:
     # Parallel promote for the apk-fast-path chromium artifact. Same dual-
     # target shape as FF promote: GHCR for CI consumption, DH for external.
+    # Triggers:
+    # - push to main (canonical promotion path; uses versions.env default PW)
+    # - workflow_dispatch with build_chromium_headless_shell=true (on-demand
+    #   catalog accumulation: dispatcher can pass pw_version to publish the
+    #   chs-${rev} tag matching a non-default PW pin)
     needs: [build-chromium-headless-shell, smoke-chromium-headless-shell]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || github.event_name == 'schedule'
+      || (github.event_name == 'workflow_dispatch' && inputs.build_chromium_headless_shell == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@v3
@@ -448,6 +492,7 @@ jobs:
   build-chromium-headless-shell:
     if: |
       github.event_name == 'push'
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.build_chromium_headless_shell == 'true')
       || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-chromium-headless-shell'))
     runs-on: ubuntu-latest
@@ -463,6 +508,13 @@ jobs:
       - id: pins
         run: |
           set -a; . playwright/alpine-browsers/versions.env; set +a
+          # workflow_dispatch override: if `pw_version` input was set, it wins
+          # over versions.env's PW_VERSION default. Powers the on-demand path
+          # where a different PW pin (e.g. 1.59.1) needs its own chs/ff rev.
+          if [ -n "${PW_VERSION_OVERRIDE:-}" ]; then
+            echo "pin override: PW_VERSION=$PW_VERSION → $PW_VERSION_OVERRIDE (workflow_dispatch input)"
+            PW_VERSION="$PW_VERSION_OVERRIDE"
+          fi
           echo "pw_version=$PW_VERSION" >> "$GITHUB_OUTPUT"
           BROWSERS_JSON=$(curl -fsSL "https://unpkg.com/playwright-core@${PW_VERSION}/browsers.json")
           REV=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .revision' <<<"$BROWSERS_JSON")
@@ -495,6 +547,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: artifact
+          build-args: |
+            EXPECTED_CHROMIUM_VERSION=${{ steps.pins.outputs.chromium_version }}
 
       - name: Tier-1 smoke (chrome-headless-shell --version)
         run: |
@@ -562,6 +616,13 @@ jobs:
       - id: pins
         run: |
           set -a; . playwright/alpine-browsers/versions.env; set +a
+          # workflow_dispatch override: if `pw_version` input was set, it wins
+          # over versions.env's PW_VERSION default. Powers the on-demand path
+          # where a different PW pin (e.g. 1.59.1) needs its own chs/ff rev.
+          if [ -n "${PW_VERSION_OVERRIDE:-}" ]; then
+            echo "pin override: PW_VERSION=$PW_VERSION → $PW_VERSION_OVERRIDE (workflow_dispatch input)"
+            PW_VERSION="$PW_VERSION_OVERRIDE"
+          fi
           echo "pw_version=$PW_VERSION" >> "$GITHUB_OUTPUT"
           BROWSERS_JSON=$(curl -fsSL "https://unpkg.com/playwright-core@${PW_VERSION}/browsers.json")
           REV=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .revision' <<<"$BROWSERS_JSON")

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -28,6 +28,7 @@ on:
       node_version:    { type: string,  default: '' }   # e.g. '20.18.0'
       pnpm_version:    { type: string,  default: '' }   # e.g. '9.15.3'
       pw_version:      { type: string,  default: '' }   # e.g. '1.50.1'
+      chs_rev:         { type: string,  default: '' }   # e.g. '1217' (chromium-headless-shell revision; alpine-only); derived from pw_version's browsers.json by on-demand-build.yml. Empty = use Dockerfile.alpine's ARG CHS_REV default (current pin).
       # All three `only_*` axes use the same convention: comma-separated friendly names,
       # empty = no filter (every default-matrix entry runs, byte-identical to today).
       # Whitespace around commas is tolerated.
@@ -626,6 +627,7 @@ jobs:
           changed_map: ${{ needs.changes.outputs.map }}
           build_args: |
             ${{ inputs.pw_version && format('PLAYWRIGHT_VERSION={0}', inputs.pw_version) || '' }}
+            ${{ inputs.chs_rev && format('CHS_REV={0}', inputs.chs_rev) || '' }}
 
   build-playwright-dind:
     runs-on: ubuntu-latest
@@ -650,6 +652,7 @@ jobs:
           changed_map: ${{ needs.changes.outputs.map }}
           build_args: |
             ${{ inputs.pw_version && format('PLAYWRIGHT_VERSION={0}', inputs.pw_version) || '' }}
+            ${{ inputs.chs_rev && format('CHS_REV={0}', inputs.chs_rev) || '' }}
 
 
   # Playwright on the node-gyp base: the SAME ./playwright layer, only the base differs (pnpm-gyp), for
@@ -677,6 +680,7 @@ jobs:
           changed_map: ${{ needs.changes.outputs.map }}
           build_args: |
             ${{ inputs.pw_version && format('PLAYWRIGHT_VERSION={0}', inputs.pw_version) || '' }}
+            ${{ inputs.chs_rev && format('CHS_REV={0}', inputs.chs_rev) || '' }}
 
   build-playwright-gyp-dind:
     runs-on: ubuntu-latest
@@ -701,6 +705,7 @@ jobs:
           changed_map: ${{ needs.changes.outputs.map }}
           build_args: |
             ${{ inputs.pw_version && format('PLAYWRIGHT_VERSION={0}', inputs.pw_version) || '' }}
+            ${{ inputs.chs_rev && format('CHS_REV={0}', inputs.chs_rev) || '' }}
 
 
   # ----------------------------------------------------------------------------

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -46,7 +46,18 @@ ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24
 # Smaller artifact than full chromium; deterministic timing for tests.
 COPY --from=chs-source /chrome-headless-shell-linux64 /ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64
 RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_COMPLETE \
- && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV}
+ && sudo chmod 755 /ms-playwright/chromium_headless_shell-${CHS_REV} \
+ # Drift warning: the producer bakes /chrome-headless-shell-linux64/.version-drift-warning
+ # when alpine:edge's chromium pkgver doesn't match PW's pinned browserVersion.
+ # PW SDK doesn't validate version at launch (path-name match is enough), but
+ # tests on version-sensitive APIs may behave differently. Echo the file at
+ # image build time so the drift is visible in build logs; image still ships.
+ && WARN=/ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64/.version-drift-warning \
+ && if [ -f "$WARN" ]; then \
+      echo "===== chromium-headless-shell version drift warning =====" >&2; \
+      cat "$WARN" >&2; \
+      echo "==========================================================" >&2; \
+    fi
 
 # Runtime. The chromium-headless-shell artifact is RPATH=$ORIGIN
 # self-contained for ELF resolution, but Chromium still touches the system

--- a/playwright/alpine-browsers/chromium-headless-shell/Dockerfile.apk
+++ b/playwright/alpine-browsers/chromium-headless-shell/Dockerfile.apk
@@ -23,6 +23,17 @@ FROM alpine:edge AS chromium-fetcher
 # `add` resolves against the cached snapshot.
 RUN apk update && apk add --no-cache chromium-headless-shell patchelf binutils
 
+# PW's expected chromium browserVersion (e.g. 148.0.7778.96). The producer
+# workflow derives this from playwright-core@${PW_VERSION}/browsers.json and
+# passes it as build-arg. We compare to the binary's actual --version output
+# below — if they drift (alpine:edge ships a different patch level than PW
+# pinned), bake a warning file into the artifact so the consumer image build
+# can surface the drift at build time. Drift is silent at PW SDK launch (PW
+# doesn't validate version, just path); the warning is the only signal.
+# Empty = no check (push/PR path with no override; produces today's edge
+# without sanity-checking against PW).
+ARG EXPECTED_CHROMIUM_VERSION=
+
 # Aports installs the binary at /usr/lib/chromium/chromium-headless-shell
 # + supporting data files (.pak, locales/, snapshot_blob.bin, etc) in the
 # same dir. The depend chromium-swiftshader provides libvk_swiftshader.so
@@ -77,6 +88,29 @@ RUN mkdir -p /chrome-headless-shell-linux64 \
     # Quick sanity: binary's ldd should show no "not found".
     && ! ldd "$DST"/chrome-headless-shell 2>&1 | grep -E "not found" \
     && "$DST"/chrome-headless-shell --version
+
+# Drift check. If EXPECTED_CHROMIUM_VERSION was passed (on-demand path), and
+# the binary's --version output doesn't carry that exact version prefix,
+# bake `.version-drift-warning` into the artifact root. Compares on the
+# first 3 dot-segments (e.g. 148.0.7778) — patch-level drift within the
+# same minor is treated as acceptable (it's what alpine:edge naturally has).
+RUN if [ -n "$EXPECTED_CHROMIUM_VERSION" ]; then \
+      ACTUAL=$(/chrome-headless-shell-linux64/chrome-headless-shell --version | awk '{print $NF}'); \
+      EXPECTED_PREFIX=$(echo "$EXPECTED_CHROMIUM_VERSION" | awk -F. '{ print $1 "." $2 "." $3 }'); \
+      case "$ACTUAL" in \
+        "$EXPECTED_PREFIX"*) \
+          echo "drift-check: OK — actual=$ACTUAL matches expected prefix $EXPECTED_PREFIX.*"; \
+          ;; \
+        *) \
+          echo "drift-check: DRIFT — actual=$ACTUAL, expected=$EXPECTED_CHROMIUM_VERSION (prefix $EXPECTED_PREFIX.*)"; \
+          printf 'Chromium version drift detected at producer build time:\n  expected (PW pin): %s\n  actual (alpine:edge apk): %s\n\nThis artifact is tagged after the EXPECTED revision but the binary is the\nACTUAL one. PW SDK will launch it (path-name match), but tests depending\non chromium-version-specific behaviors may surface differences.\n' \
+              "$EXPECTED_CHROMIUM_VERSION" "$ACTUAL" \
+              > /chrome-headless-shell-linux64/.version-drift-warning; \
+          ;; \
+      esac; \
+    else \
+      echo "drift-check: skipped (no EXPECTED_CHROMIUM_VERSION build-arg)"; \
+    fi
 
 # ---- Artifact ----------------------------------------------------------------
 FROM scratch AS artifact

--- a/playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Resolve which Alpine aports commit shipped a given chromium pkgver. Used by
+# the producer to source chromium-headless-shell at a specific Chrome-for-
+# Testing version when the active alpine:edge no longer ships it.
+#
+# Input:   the target chromium version as it appears in
+#          `community/chromium/APKBUILD` pkgver, derived earlier from
+#          playwright-core@${PW_VERSION}/browsers.json (e.g. 147.0.7727.15).
+#          The match is on the `<major>.<minor>.<patch>` prefix — pkgver may
+#          carry a fourth `.<build>` segment that doesn't always align with
+#          PW's recorded browserVersion.
+#
+# Output:  the aports commit SHA on stdout (single line).
+#
+# Algorithm:
+#   1. GET the commit history for community/chromium/APKBUILD via gitlab API
+#      (paginated newest-first; 100 commits / page).
+#   2. For each commit, GET the raw APKBUILD at that ref and grep pkgver=.
+#   3. Return the first SHA whose pkgver matches the target prefix.
+#   4. Fail loud if no match within 100 commits (~6 months of history) —
+#      caller should surface a clearer guidance message ("PW version too
+#      old; aports no longer carries that chromium pkgver").
+#
+# Usage:   resolve-aports-ref.sh 147.0.7727.15
+#          → emits "abc1234def…" on stdout
+#
+# This script runs at producer build time (inside Dockerfile.apk's
+# chromium-fetcher stage), NOT at consumer build time. The consumer image
+# only sees the resolved apk artifact, never the SHA.
+
+set -euo pipefail
+
+TARGET="${1:-}"
+[[ -n "$TARGET" ]] || { echo "usage: $0 <chromium-version>" >&2; exit 1; }
+
+# Match on the first three dot-segments only (major.minor.patch). Aports'
+# pkgver can include a fourth build segment that doesn't appear in PW's
+# browsers.json browserVersion field; treating it as a prefix lets the
+# match succeed regardless.
+PREFIX=$(echo "$TARGET" | awk -F. '{ print $1 "." $2 "." $3 }')
+
+command -v jq   >/dev/null || { echo "resolve-aports-ref: jq required"   >&2; exit 1; }
+command -v curl >/dev/null || { echo "resolve-aports-ref: curl required" >&2; exit 1; }
+
+# URL-encoded project path: alpine/aports → alpine%2Faports.
+PROJECT="alpine%2Faports"
+COMMITS_URL="https://gitlab.alpinelinux.org/api/v4/projects/${PROJECT}/repository/commits"
+RAW_URL_BASE="https://gitlab.alpinelinux.org/alpine/aports/-/raw"
+
+echo "resolve-aports-ref: searching aports for chromium pkgver matching ${PREFIX}.*" >&2
+
+# 100 commits / page; one page is enough for ~6 months of chromium activity.
+# If we ever need older history, bump per_page or paginate.
+commits_json=$(curl -fsSL "${COMMITS_URL}?path=community/chromium/APKBUILD&per_page=100")
+
+# Iterate newest-first. `< <(…)` (process substitution) keeps the loop in the
+# current shell so `exit` propagates, unlike `… | while` which spawns a subshell
+# in bash and can't propagate exit codes back.
+while read -r sha; do
+  # Fetch the APKBUILD at this commit. The raw URL serves the file unchanged;
+  # awk grabs the first pkgver line; `tr -d` strips quotes.
+  pkgver=$(curl -fsSL "${RAW_URL_BASE}/${sha}/community/chromium/APKBUILD" 2>/dev/null \
+    | awk -F= '/^pkgver=/ { print $2; exit }' \
+    | tr -d '"' \
+    || true)
+  [[ -z "$pkgver" ]] && continue
+
+  case "$pkgver" in
+    "$PREFIX"*)
+      echo "resolve-aports-ref: matched at ${sha} (pkgver=${pkgver})" >&2
+      echo "$sha"
+      exit 0
+      ;;
+  esac
+done < <(echo "$commits_json" | jq -r '.[].id')
+
+echo "resolve-aports-ref: no aports commit found shipping chromium ${PREFIX}.* within the latest 100 APKBUILD commits" >&2
+exit 2


### PR DESCRIPTION
## Why

The on-demand build flow lets users post a build-request issue with a non-default `pw_version` (e.g. PW 1.59.1 in [#36](https://github.com/jclaveau/github-action-container-images/issues/36)). `on-demand-build.yml` parses the form, forwards `pw_version` to `test-and-publish.yml`, which sets `--build-arg PLAYWRIGHT_VERSION=...`. So far so good.

But `playwright/Dockerfile.alpine`'s `ARG CHS_REV=1223` (chromium-headless-shell revision baked into PW 1.60.0's `browsers.json`) doesn't follow the PW version. If a requester pins PW 1.59.1, the image:

1. COPYs the producer's `chs-1223` tag (PW 1.60.0's pin), not the chs-1217 that PW 1.59.1 expects.
2. `pnpm install -g playwright@1.59.1` installs PW 1.59.1 SDK.
3. At test launch, PW SDK reads its own `browsers.json` → expects `/ms-playwright/chromium_headless_shell-1217/...`. Finds `/ms-playwright/chromium_headless_shell-1223/...` instead. → `Executable doesn't exist`.

This PR closes the gap end-to-end.

## What

End-to-end CHS_REV propagation: on-demand-build derives → test-and-publish forwards → Dockerfile.alpine receives.

- **`.github/workflows/on-demand-build.yml`**: new `derive-chs` step. Curls `https://unpkg.com/playwright-core@${PW}/browsers.json`, resolves the chs revision, and pre-flights `docker manifest inspect chs-${CHS_REV}` against GHCR. Missing tag → fail-loud with guidance to dispatch the producer first. No more wasted ~10 min consumer builds that 404 at COPY time.
- **`.github/workflows/test-and-publish.yml`**: new `chs_rev` workflow_call input. Forwarded as `--build-arg CHS_REV=…` to all 4 `build-playwright-{dood,dind}{,-gyp}` jobs.
- **`.github/workflows/playwright-alpine-browsers.yml`** (producer):
  - new `workflow_dispatch.pw_version` input — overrides `versions.env`'s `PW_VERSION` at run time. The 3 existing `id: pins` steps already source versions.env; the override is workflow-level env `PW_VERSION_OVERRIDE`.
  - new `schedule: 0 6 * * 0` (weekly Sun) — catalog accumulator. Locks in alpine:edge's current chromium under its matching `chs-${rev}` tag while the apk is still pullable; later PW versions whose chromium aligned with that snapshot stay supportable on-demand. FF excluded from the cron (2-3h build; the chs apk-extraction is ~5 min).
  - chs build passes `EXPECTED_CHROMIUM_VERSION` build-arg to `Dockerfile.apk` so the producer can bake a `.version-drift-warning` file when the binary's reported version doesn't match PW's pinned `browserVersion`. PW SDK is silent on the drift at launch (path-name match is enough); this is the only signal.
  - chs promote job now also runs on `workflow_dispatch` (was push-only), so on-demand dispatches actually publish the `chs-${rev}` tag.
- **`playwright/alpine-browsers/chromium-headless-shell/Dockerfile.apk`**: new `ARG EXPECTED_CHROMIUM_VERSION` + drift-detection block. Compares `chrome --version` against the expected value on first 3 dot-segments; bakes `.version-drift-warning` if mismatch. Build always succeeds (we prefer ship+nag over hard-reject — the drift is small in practice).
- **`playwright/Dockerfile.alpine`** (consumer): surfaces `.version-drift-warning` to stderr at consumer image build time, so drifted builds are visible in the GHA logs without changing runtime behavior.
- **`playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh`** (new): maps a chromium pkgver to the aports commit that shipped it. Not on the hot build path (see Open question 3); kept for diagnostics + a possible future "build chs from source at a specific commit" follow-up.

## Open questions for the reviewer

- **Drift policy**: I went with ship+nag (publish the artifact with the drift-warning file, echo at consumer build time). The alternative was hard-reject (refuse to publish if binary version != PW pin), which would have made #36 unbuildable today (alpine:edge has 148.x, PW 1.59.1 pinned 147.x). For most tests the drift is benign — PW SDK doesn't validate the binary version. Is the ship+nag stance the right trade?
- **Catalog cron cadence**: Sunday 06:00 UTC weekly. Too frequent (we re-promote `chs-${rev}` even when alpine:edge didn't move) or about right? A no-op promote is cheap (`imagetools create` server-side); rebuild + smoke takes ~10 min.
- **Aports resolver script**: I wrote `resolve-aports-ref.sh` early in the design when I thought we could fetch historical apks from gitlab CI artifacts. Turns out alpine doesn't archive per-commit (CI pipelines for community/chromium APKBUILD edits are `merge_request_event/skipped`, no artifacts). The script is now diagnostic-only. Worth removing, or keep as scaffolding for a "build chs from source at a commit" follow-up if someone needs older chromium pins?

## Retrocompat

- `test-and-publish.yml` push-on-main: no input change. Dockerfile.alpine's `ARG CHS_REV=1223` default applies; same artifact COPY as today.
- Producer push-on-main: no behavior change. Schedule trigger is new but disjoint (filters on `event_name == 'schedule'`).
- On-demand request with no PW version: `derive-chs` outputs empty → no `CHS_REV` build-arg → Dockerfile.alpine default applies.

## Out of scope (explicit)

- **Auto-dispatch producer when chs-${rev} is missing**. The user-friendly path, but cross-workflow dispatch + wait-for-completion in YAML is brittle. Manual producer dispatch first, then reopen the issue is the unambiguous flow. The pre-flight error message guides the requester.
- **Same mechanism for Firefox** (ff_rev derivation + ff-${rev} pre-flight). Same code path, plugs in trivially once FF on alpine ships. Not added now to keep this PR scoped.
- **Renovate auto-bump of CHS_REV**: Renovate today tracks the producer tag via `playwright/Dockerfile.alpine`'s ARG default. Unchanged; the on-demand input is the override-when-different path.

## Depends on

- Producer PRs #17 + #40 merged (consumer wiring is on main).
- Consumer PR #39 merged (Dockerfile.alpine already accepts `ARG CHS_REV` — no Dockerfile structural change needed).

Assisted-by: Claude:claude-opus-4-7