### PR TITLE
fix(on-demand): post issue comment when prepare-stage check fails

### DIFF
--- a/.github/workflows/on-demand-build.yml
+++ b/.github/workflows/on-demand-build.yml
@@ -255,10 +255,36 @@ jobs:
 
   comment-close:
     needs: [prepare, build]
-    # Run after the build attempt. `always()` so failures still get a comment.
-    if: always() && needs.prepare.result == 'success'
+    # Run after build OR after prepare-side failure. The previous gate
+    # (`prepare.result == 'success'`) silently dropped derive-chs's
+    # pre-flight rejection — issue got no comment, only `::error` in the
+    # Actions UI. `always()` so prepare-failure → comment; the
+    # build-request label check filters out unrelated issue/comment
+    # events that would otherwise trip the new prepare-fail step.
+    if: always() && contains(github.event.issue.labels.*.name, 'build-request')
     runs-on: ubuntu-latest
     steps:
+      - name: Comment prepare failure + label
+        # Pre-flight rejection (chs-${rev} tag missing on GHCR, PW version
+        # not resolvable, parse error, etc.) — surface the failure in the
+        # issue with a retry box so the requester can re-fire after fixing
+        # the underlying cause (e.g. dispatching the producer manually).
+        if: needs.prepare.result != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo ":x: Build request rejected at the prepare stage (status: \`${{ needs.prepare.result }}\`)."
+            echo
+            echo "Logs: $RUN_URL — typically the chromium-headless-shell tag matching the requested PW version isn't published yet. Dispatch [\`playwright-alpine-browsers.yml\`](${{ github.server_url }}/${{ github.repository }}/actions/workflows/playwright-alpine-browsers.yml) with \`build_chromium_headless_shell=true\` and \`pw_version=<your pin>\`, then click the retry box below."
+            echo
+            echo "- [ ] Re-run this build"
+          } > /tmp/prepare-fail-comment.md
+          gh issue comment "${{ github.event.issue.number }}" --body-file /tmp/prepare-fail-comment.md
+          gh issue edit "${{ github.event.issue.number }}" --remove-label building --add-label build-failed || \
+            gh issue edit "${{ github.event.issue.number }}" --add-label build-failed
+
       - id: detect-chromium-drift
         # Alpine playwright variants COPY the chromium-headless-shell artifact
         # from the producer. If the producer's edge-current chromium pkgver
@@ -345,7 +371,10 @@ jobs:
           gh issue edit "${{ github.event.issue.number }}" --remove-label building --add-label published
           gh issue close "${{ github.event.issue.number }}"
       - name: Comment failure + label
-        if: needs.build.result != 'success'
+        # Only when the build job actually ran AND failed. When prepare
+        # itself fails, `build.result == 'skipped'` and the prepare-fail
+        # step above already posted a tailored comment — don't double-post.
+        if: needs.prepare.result == 'success' && needs.build.result != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Why

PR #41 added a pre-flight tag check (`derive-chs` in `prepare`) that rejects build requests whose chs-${rev} tag isn't yet on GHCR. The `::error` shows in the Actions UI, but the issue itself got nothing — `comment-close.if` was gated on `prepare.result == 'success'`, so prepare-side failures silently dropped.

Reopening [#36](https://github.com/jclaveau/github-action-container-images/issues/36) just now confirmed: the workflow ran, pre-flight rejected (PW 1.59.1 needs chs-1217, not published), `::error` in the run logs with the dispatch guidance — but the issue has no comment, still wears the `building` label, and there's no retry box. Requester would have to navigate to Actions to figure out why nothing happened.

## What

- Relax `comment-close.if` from `prepare.result == 'success'` to `always() && contains(labels, 'build-request')`. The label check mirrors `prepare.if`'s guard so unrelated issue/comment events don't trip the new step.
- New step **`Comment prepare failure + label`** fires on `needs.prepare.result != 'success'`. Posts:
  - `:x: Build request rejected at the prepare stage`
  - Run URL
  - The typical cause + the exact dispatch command for the producer
  - The `- [ ] Re-run this build` retry box (the existing `notify-retry` path picks up on flip)
  - Swaps `building` → `build-failed` label.
- Tighten the existing build-failure step's `if:` to `prepare.result == 'success' && build.result != 'success'` so it doesn't double-post when prepare failed (build would be `skipped`, which the old `!= 'success'` matched).

## Open questions for the reviewer

- The prepare-fail comment hard-codes the chs-${rev}-missing case as the "typical cause" in its body. That's the most common failure mode but not the only one (older PW versions without chromium-headless-shell, parse errors). Worth pulling the actual `::error` line from the run instead of hard-coding? Adds an extra API call but more precise.
- I kept the retry box even on prepare-fail. The producer-dispatch step is still manual (out of scope for PR 41), so the requester has to do that BEFORE clicking retry. The comment text says so but it's a 2-step flow. Acceptable, or should the retry box be omitted on prepare-fail to avoid implying one-click recovery?

## Out of scope

- Auto-dispatching the producer when chs-${rev} is missing (still the user-friendly path; cross-workflow dispatch + wait-for-completion in YAML is brittle — PR 41 plan deferred this).
- Symmetric treatment for FF (no `ff-rev` derivation yet; FF on alpine is itself deferred).

Assisted-by: Claude:claude-opus-4-7