### PR TITLE
fix(ci): align alpine vanilla-config test to image's PW version

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1202,7 +1202,14 @@ jobs:
         run: |
           mkdir -p /tmp/pw-vanilla && cd /tmp/pw-vanilla
           echo '{"name":"v","version":"1.0.0"}' > package.json
-          pnpm add -D @playwright/test
+          # Align to the image's PW CLI version — same trick as the
+          # "Align fixture to image's Playwright version" step above. An
+          # unversioned `pnpm add -D @playwright/test` resolves to LATEST
+          # which expects whatever chromium revision LATEST pins, but the
+          # image staged the revision matching the image's PLAYWRIGHT_VERSION
+          # build-arg (set by on-demand-build's chs_rev derivation).
+          PW_VERSION="$(playwright --version | awk '{print $2}')"
+          pnpm add -D "@playwright/test@$PW_VERSION"
           cat > playwright.config.ts <<'TS'
           import { defineConfig } from '@playwright/test';
           export default defineConfig({ projects: [{ name: 'chromium' }] });


### PR DESCRIPTION
## Why

PR #39's alpine vanilla-config regression test installed @playwright/test unversioned (\`pnpm add -D @playwright/test\`). pnpm resolved that to LATEST. Fine for the default-PW path (image's PW pin == LATEST). Breaks the on-demand path (image's PW pin from a build-request issue's form != LATEST).

Surfaced on the [#36](https://github.com/jclaveau/github-action-container-images/issues/36) reopen post-PR-41-merge:

- Image built with \`--build-arg CHS_REV=1217\` (PW 1.59.1's pin) ✓
- chromium-headless-shell staged at \`/ms-playwright/chromium_headless_shell-1217/...\` ✓
- Primary \`pnpm playwright test\` in \`playwright/\` PASSED (fixture realigned by the \"Align fixture\" step at line 1183) ✓
- Vanilla-config step FAILED — \`pnpm add -D @playwright/test\` resolved LATEST = PW 1.60.0, which expects \`chromium_headless_shell-1223\`. ✗

## What

Mirror the \"Align fixture\" trick in the vanilla-config step: read \`playwright --version\` from the image's globally-installed CLI, pin \`@playwright/test\` to that version.

## Retrocompat

Default-PW path unchanged: \`playwright --version\` returns the image's PLAYWRIGHT_VERSION ARG default (same value LATEST resolved to when no on-demand override). Vanilla-config keeps testing the documented contract (zero-config auto-discovery) on the right SDK version.

## Out of scope

- Same UX gap on the dispatch-the-producer-manually flow is now fixed by PR #42 (prepare-fail comment).
- Per-PW chromium-version drift detection at consumer build time + issue comment surfacing already in PR #41.

Assisted-by: Claude:claude-opus-4-7