### PR TITLE
firefox: exclude universal runtime libs from .so bundle

### DIFF
--- a/playwright/alpine-browsers/Dockerfile
+++ b/playwright/alpine-browsers/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
         bash curl git patch patchutils tar xz gzip jq gettext-envsubst make sccache \
         alsa-lib-dev automake bsd-compat-headers cargo cbindgen \
         clang22 clang22-libclang clang22-dev compiler-rt \
-        dbus dbus-dev gettext gtk+3.0-dev hunspell-dev icu-dev \
+        dbus dbus-dev gettext gtk+3.0-dev hunspell-dev icu-dev icu-data-full \
         libevent-dev libffi-dev libjpeg-turbo-dev libnotify-dev libogg-dev \
         libtheora-dev libtool libvorbis-dev libvpx-dev libwebp-dev \
         libxcomposite-dev libxt-dev lld22 llvm22-dev m4 mesa-dev \

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -535,6 +535,27 @@ for so in "$DST"/*.so*; do
   patchelf --set-rpath '$ORIGIN' "$so" 2>/dev/null || true
 done
 
+# ICU data file. aports builds firefox with --with-system-icu, and Alpine's
+# libicudata.so.78 is a 12 KB stub — the actual locale data ships separately
+# as /usr/share/icu/${ver}/icudt${maj}l.dat in the icu-data-full apk. At
+# runtime libicuuc stats that absolute path; on a consumer base with a
+# different ICU major (alpine 3.21 has ICU 76, builder edge has 78) the stat
+# returns ENOENT and the load deref's null → SEGV at XPCOM init. Bundle the
+# data file next to the .so files; the consumer image sets
+# ICU_DATA=<bundle dir> so libicuuc finds it without the absolute path.
+ICU_VER=$(ls /usr/share/icu/ 2>/dev/null | head -1)
+if [ -n "$ICU_VER" ]; then
+  ICU_DAT=$(ls /usr/share/icu/"$ICU_VER"/icudt*l.dat 2>/dev/null | head -1)
+  if [ -f "$ICU_DAT" ]; then
+    cp -aL "$ICU_DAT" "$DST"/
+    echo "===== Bundled ICU data: $(basename "$ICU_DAT") (icu $ICU_VER) ====="
+  else
+    echo "WARN: /usr/share/icu/$ICU_VER/icudt*l.dat not found; consumer may segfault at XPCOM init" >&2
+  fi
+else
+  echo "WARN: no ICU data dir under /usr/share/icu/ on builder" >&2
+fi
+
 # Sanity check: no "not found" in libxul ldd. Fail loud at producer time,
 # not silently at consumer runtime. (firefox-bin is small; libxul.so is the
 # fat one and most likely to surface missing deps.)

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -488,13 +488,31 @@ echo "===== Bundling .so deps + patchelf RPATH=\$ORIGIN ====="
 DST=/work/firefox-dist
 FF_BINS="$DST/firefox $DST/firefox-bin $DST/glxtest $DST/vaapitest $DST/pingsender"
 
+# Universal-runtime libs that MUST resolve from the consumer's base, not the
+# bundle. The binary's ELF interpreter is hardcoded to the system loader
+# (/lib/ld-musl-x86_64.so.1) — patchelf --set-interpreter can't be relative —
+# so the loader+libc ABI is fixed by the consumer's musl version. If we bundle
+# our build-time copies, peer .so files resolve them via RPATH=$ORIGIN and end
+# up calling a different libc than the loader, which corrupts dynamic linker
+# state and segfaults at XPCOM init when the consumer base's musl version
+# diverges from the builder's (e.g. consumer alpine 3.21 musl 1.2.5-r11 vs
+# builder alpine:edge musl 1.2.6-r0). Skip and let the system loader pick up
+# the consumer's matching copies via default search paths.
+# - ld-musl-x86_64.so.1: musl loader/libc. Same file as libc.musl-x86_64.so.1.
+# - libgcc_s.so.1, libstdc++.so.6: GCC runtime/C++ stdlib. Tracks the system
+#   toolchain; bundling a foreign-version copy breaks libc-coupled symbols
+#   (__cxa_thread_atexit_impl etc).
+EXCLUDE_LIBS="ld-musl-x86_64.so.1 libc.musl-x86_64.so.1 libgcc_s.so.1 libstdc++.so.6"
+
 # Walk ldd on a target, copy system .so deps into $DST (top level only —
 # nested gmp-clearkey/ etc. dlopen explicitly and inherit firefox's RPATH).
 ldd_walk() {
   local target="$1"
   [ -e "$target" ] || return 0
   for so in $(ldd "$target" 2>/dev/null | awk '{print $3}' | grep '^/' || true); do
-    [ -f "$so" ] && [ ! -f "$DST/$(basename "$so")" ] && cp -aL "$so" "$DST"/ || true
+    base=$(basename "$so")
+    case " $EXCLUDE_LIBS " in *" $base "*) continue ;; esac
+    [ -f "$so" ] && [ ! -f "$DST/$base" ] && cp -aL "$so" "$DST"/ || true
   done
 }
 


### PR DESCRIPTION
## Why

The musl FF artifact is published but consumer wiring in `playwright/Dockerfile.alpine` is still gated off (see [`feat-alpine-consumer-wiring` revert commit 00cc2fa](https://github.com/jclaveau/github-action-container-images/commit/00cc2fa): "FF on alpine 3.21 segfaults at XPCOM init because the producer artifact was built on alpine edge — bundled libstdc++/libgcc_s/ld-musl differ in ABI from the consumer base's musl 1.2.5-r11 vs producer's r21.")

The repro is sharp: `firefox --version` works, but `--headless -profile` crashes. The reason — the binary's ELF interpreter is the system loader (`patchelf --set-interpreter` can't take `\$ORIGIN`), so the consumer's musl libc is what's actually loaded. But peer .so files in the bundle have `RPATH=\$ORIGIN` and find the BUILDER's `ld-musl-x86_64.so.1` / `libstdc++.so.6` / `libgcc_s.so.1` first. Two libc ABIs in one process → segfault.

## What

Skip those three universal runtime libs in `ldd_walk`. Everything else stays bundled (ICU 78, NSPR, NSS, cairo, …) — the cross-alpine drift insulation we want.

## Verification I'd love to see

- [ ] Producer FF rebuild on this branch publishes a new `ff-1522` whose `/firefox/` dir has none of `ld-musl-x86_64.so.1`, `libstdc++.so.6`, `libgcc_s.so.1`
- [ ] Tier-1 + Tier-2 smoke on the producer side both pass
- [ ] Consumer-side `firefox -headless -profile \$TMPDIR` succeeds against the rebuilt artifact on alpine 3.21 (smoke from the `feat-alpine-consumer-wiring` branch)

## Out of scope

- Consumer wiring (`playwright/Dockerfile.alpine`'s FF COPY block, `firefox` runtime apks, vanilla-config probe for `/etc/alpine-release`) — that's the prior `feat-alpine-consumer-wiring` branch. Once this PR's artifact validates, that one rebases cleanly.
- Switching the producer alpine version (`ALPINE_VERSION=edge` → `3.21`) — the original alternative. Discarded because aports HEAD's APKBUILD pins `_llvmver=22` which 3.21 doesn't ship.
- The trailing `docs(readmes)` commit is unrelated README-DRY cleanup that was hitchhiking on the local worktree; happy to split out if preferred.

Assisted-by: Claude:claude-opus-4-7