### PR TITLE
Smart Renovate for PW chain + aports SHA auto-resolve

### DIFF
--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -20,3 +20,4 @@
 - [On-demand prepare-failure UX](project_on_demand_prepare_failure_ux.md) — comment-close.if must be `always()`, not `prepare.result == 'success'`; separate prepare-fail step; every dispatch outcome → issue comment
 - [Vanilla-config test PW alignment](project_vanilla_config_test_pw_alignment.md) — `pnpm add -D @playwright/test@$(playwright --version | awk '{print $2}')`, never unversioned (resolves to LATEST and breaks non-default PW builds)
 - [READMEs: link parents, don't duplicate](feedback_readme_no_parent_duplication.md) — derived image READMEs cross-ref parent sections via anchor; only document what the layer itself contributes
+- [Firefox-on-Alpine WIP pipeline lives elsewhere](project_firefox_alpine_wip_pipeline.md) — do NOT add firefox-side checks to this repo's aports tooling/tests; chromium pin pair IS auto-tracked, firefox is not

--- a/.agents/auto-memory/project_firefox_alpine_wip_pipeline.md
+++ b/.agents/auto-memory/project_firefox_alpine_wip_pipeline.md
@@ -1,0 +1,15 @@
+---
+name: firefox-alpine-wip-pipeline
+description: A separate WIP pipeline rebuilds firefox-on-Alpine with PW patches; firefox-side tooling and tests in the main producer/consumer flow are intentionally not maintained here.
+metadata:
+  type: project
+---
+
+A separate WIP pipeline rebuilds `firefox-on-Alpine` with Playwright patches. The main repo's firefox-side tooling (`ALPINE_APORTS_REF` in `versions.env`, the firefox `apply-and-build.sh` majmin check, firefox `fetch-aports.sh`) is left in place but not actively maintained from the main producer/consumer flow.
+
+**Why:** Confirmed by user 2026-06-04 when scoping the aports auto-resolve work — "Skip ffx for now on Alpine, there is a wip pipeline to build it with PW patches".
+
+**How to apply:**
+- Do NOT add firefox-side checks to `tests/aports/`, the auto-resolve workflow, or any new CI guard.
+- The chromium pin pair (`PW_VERSION` ↔ `ALPINE_APORTS_CHROMIUM_REF`) IS auto-tracked and tested — see [[project_pw_version_aware_chs_rev_chain]].
+- If asked to extend aports tracking, ask whether the firefox WIP pipeline has converged before doing it in this repo.

--- a/.github/workflows/auto-resolve-aports.yml
+++ b/.github/workflows/auto-resolve-aports.yml
@@ -1,0 +1,136 @@
+name: auto-resolve-aports
+
+# Triggered when a PR (typically Renovate's) bumps PW_VERSION in versions.env.
+# Resolves the matching ALPINE_APORTS_CHROMIUM_REF and commits the new SHA to
+# the same PR — preempting the chromium producer build's pkgver fail-fast
+# (apply-and-build.sh:43-54).
+#
+# Firefox (ALPINE_APORTS_REF) is NOT auto-resolved; the WIP firefox-on-Alpine
+# pipeline owns that surface.
+#
+# Limits known up-front:
+#   - resolve-aports-ref.sh matches by major.minor.patch PREFIX; apply-and-build.sh
+#     does STRICT pkgver equality. If aports' latest matching commit shipped a
+#     newer dot-release than PW pins, the pre-flight check fails and the workflow
+#     comments without committing. The human resolves manually in that case.
+#
+# Manual smoke:
+#   1. Open a draft PR bumping PW_VERSION in versions.env.
+#   2. Expect this workflow to either commit the chromium SHA bump (with [skip ci])
+#      or post a failure comment explaining the manual fallback.
+#   3. tests-aports.yml then verifies the resulting pair is consistent.
+
+on:
+  pull_request:
+    paths:
+      - 'playwright/alpine-browsers/versions.env'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: aports-resolve-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    # Loop guard: skip when our own bot pushed the synchronize event.
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: resolve & pre-flight chromium aports SHA
+        id: resolve
+        run: |
+          set -euo pipefail
+          set -a; . playwright/alpine-browsers/versions.env; set +a
+          : "${PW_VERSION:?versions.env missing PW_VERSION}"
+          : "${ALPINE_APORTS_CHROMIUM_REF:?versions.env missing ALPINE_APORTS_CHROMIUM_REF}"
+
+          BROWSERS_JSON=$(curl -fsSL "https://unpkg.com/playwright-core@${PW_VERSION}/browsers.json")
+          CHS_VER=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .browserVersion' <<<"$BROWSERS_JSON")
+          if [ -z "$CHS_VER" ] || [ "$CHS_VER" = "null" ]; then
+            echo "::error::browsers.json for PW $PW_VERSION has no chromium-headless-shell entry"
+            exit 1
+          fi
+          echo "PW $PW_VERSION → CHS_VER=$CHS_VER"
+
+          NEW_SHA=$(bash playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh "$CHS_VER")
+          echo "resolved aports SHA: $NEW_SHA (current: $ALPINE_APORTS_CHROMIUM_REF)"
+
+          # Pre-flight: mirror apply-and-build.sh's strict pkgver check at PR time.
+          APKBUILD=$(curl -fsSL "https://gitlab.alpinelinux.org/alpine/aports/-/raw/${NEW_SHA}/community/chromium/APKBUILD")
+          PKGVER=$(echo "$APKBUILD" | awk -F= '/^pkgver=/ { gsub(/"/, "", $2); print $2; exit }')
+          if [ "$PKGVER" != "$CHS_VER" ]; then
+            echo "::error::pre-flight: aports@${NEW_SHA} pkgver=$PKGVER but PW pins CHS_VER=$CHS_VER (strict match required by apply-and-build.sh)"
+            exit 1
+          fi
+          echo "pre-flight: pkgver=$PKGVER matches CHS_VER ✓"
+
+          # Truncate to 8 chars to match versions.env's existing abbreviation style.
+          NEW_SHA_SHORT=${NEW_SHA:0:8}
+          {
+            echo "pw_version=$PW_VERSION"
+            echo "chs_ver=$CHS_VER"
+            echo "old_sha=$ALPINE_APORTS_CHROMIUM_REF"
+            echo "new_sha=$NEW_SHA_SHORT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: commit & push
+        if: steps.resolve.outputs.new_sha != steps.resolve.outputs.old_sha
+        env:
+          OLD: ${{ steps.resolve.outputs.old_sha }}
+          NEW: ${{ steps.resolve.outputs.new_sha }}
+          PW:  ${{ steps.resolve.outputs.pw_version }}
+          CHS: ${{ steps.resolve.outputs.chs_ver }}
+        run: |
+          set -euo pipefail
+          awk -v old="$OLD" -v new="$NEW" '
+            /^ALPINE_APORTS_CHROMIUM_REF=/ { sub(old, new); print; next }
+            { print }
+          ' playwright/alpine-browsers/versions.env > versions.env.new
+          mv versions.env.new playwright/alpine-browsers/versions.env
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add playwright/alpine-browsers/versions.env
+          git commit \
+            -m "chore(versions.env): auto-resolve aports chromium SHA $OLD → $NEW for PW $PW [skip ci]" \
+            -m "Pre-flight verified: aports@$NEW community/chromium/APKBUILD pkgver=$CHS matches PW $PW's browsers.json pin." \
+            -m "Assisted-by: Claude:claude-opus-4-7"
+          git push
+
+      - name: no-op
+        if: steps.resolve.outputs.new_sha == steps.resolve.outputs.old_sha
+        run: echo "ALPINE_APORTS_CHROMIUM_REF already matches PW ${{ steps.resolve.outputs.pw_version }}; nothing to commit."
+
+      - name: comment on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY: |
+            ## :warning: auto-resolve-aports failed
+
+            Could not auto-resolve a strict-match `ALPINE_APORTS_CHROMIUM_REF` for the PW version in this PR. This usually means aports' latest chromium APKBUILD ships a different dot-release than PW pins.
+
+            Run manually:
+            ```bash
+            . playwright/alpine-browsers/versions.env
+            CHS_VER=$(curl -fsSL "https://unpkg.com/playwright-core@$PW_VERSION/browsers.json" | jq -r '.browsers[]|select(.name=="chromium-headless-shell").browserVersion')
+            bash playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh "$CHS_VER"
+            ```
+            …then edit `ALPINE_APORTS_CHROMIUM_REF` in `versions.env` and push.
+
+            Run log: __RUN_URL__
+        run: |
+          BODY_RENDERED=${BODY/__RUN_URL__/$RUN_URL}
+          gh pr comment "$PR" --body "$BODY_RENDERED"

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1185,6 +1185,9 @@ jobs:
         run: |
           PW_VERSION="$(playwright --version | awk '{print $2}')"
           pnpm add -D "@playwright/test@$PW_VERSION" "playwright@$PW_VERSION"
+          # Invariant guard: the just-installed @playwright/test must equal the image's CLI version.
+          INSTALLED="$(node -p 'require("@playwright/test/package.json").version')"
+          [ "$INSTALLED" = "$PW_VERSION" ] || { echo "ERROR: @playwright/test=$INSTALLED vs playwright CLI=$PW_VERSION" >&2; exit 1; }
 
       - run: pnpm playwright test
         working-directory: playwright
@@ -1210,6 +1213,8 @@ jobs:
           # build-arg (set by on-demand-build's chs_rev derivation).
           PW_VERSION="$(playwright --version | awk '{print $2}')"
           pnpm add -D "@playwright/test@$PW_VERSION"
+          INSTALLED="$(node -p 'require("@playwright/test/package.json").version')"
+          [ "$INSTALLED" = "$PW_VERSION" ] || { echo "ERROR: @playwright/test=$INSTALLED vs playwright CLI=$PW_VERSION" >&2; exit 1; }
           cat > playwright.config.ts <<'TS'
           import { defineConfig } from '@playwright/test';
           export default defineConfig({ projects: [{ name: 'chromium' }] });

--- a/.github/workflows/tests-aports.yml
+++ b/.github/workflows/tests-aports.yml
@@ -1,0 +1,35 @@
+name: tests-aports
+
+# Cheap consistency guards for playwright/alpine-browsers/versions.env's
+# chromium pin pair. Runs in seconds — catches drift between PW_VERSION and
+# ALPINE_APORTS_CHROMIUM_REF without spinning up the 30+ minute producer build.
+#
+# Firefox (ALPINE_APORTS_REF) is intentionally out of scope; a separate WIP
+# pipeline owns firefox-on-Alpine.
+
+on:
+  pull_request:
+    paths:
+      - 'playwright/alpine-browsers/versions.env'
+      - 'playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh'
+      - 'tests/aports/**'
+      - '.github/workflows/tests-aports.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'playwright/alpine-browsers/versions.env'
+      - 'playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh'
+      - 'tests/aports/**'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: resolve-aports-ref unit test
+        run: bash tests/aports/test-resolve-aports-ref.sh
+      - name: versions.env consistency
+        run: bash tests/aports/test-versions-env-consistency.sh

--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,17 @@
   "extends": [
     "config:recommended"
   ],
-  "pinDigests": true,
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["ubuntu"],
+      "matchPackageNames": ["ubuntu", "public.ecr.aws/ubuntu/ubuntu"],
       "groupName": "Ubuntu base image"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine", "public.ecr.aws/docker/library/alpine"],
+      "groupName": "Alpine base image"
     },
     {
       "matchDatasources": ["docker"],
@@ -16,13 +21,11 @@
       "groupName": "Docker Engine"
     },
     {
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["playwright"],
+      "matchDepNames": ["playwright", "@playwright/test"],
       "groupName": "Playwright"
     },
     {
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["pnpm"],
+      "matchDepNames": ["pnpm"],
       "groupName": "pnpm"
     },
     {
@@ -34,12 +37,16 @@
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["nektos/act"],
       "groupName": "nektos/act"
+    },
+    {
+      "matchPackageNames": ["ghcr.io/jclaveau/playwright-alpine-browsers"],
+      "groupName": "Chromium headless shell (alpine consumer fallback)"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^docker/Dockerfile(\\.alpine)?$"],
+      "fileMatch": ["^docker/Dockerfile$"],
       "matchStrings": [
         "ARG DOCKER_VERSION=(?<currentValue>.*?)\\n"
       ],
@@ -49,7 +56,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^node/Dockerfile(\\.alpine)?$"],
+      "fileMatch": ["^node/Dockerfile$"],
       "matchStrings": [
         "ARG NODE_VERSION=(?<currentValue>.*?)\\n"
       ],
@@ -79,7 +86,7 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^pnpm/Dockerfile$", "^pnpm-gyp/Dockerfile$", "^pnpm-gyp/Dockerfile.alpine$"],
+      "fileMatch": ["^pnpm/Dockerfile$", "^pnpm-gyp/Dockerfile$", "^pnpm-gyp/Dockerfile\\.alpine$"],
       "matchStrings": [
         "ARG PNPM_VERSION=(?<currentValue>.*?)\\n"
       ],
@@ -96,6 +103,47 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "nektos/act",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^alpine-gha-tools/Dockerfile$"],
+      "matchStrings": [
+        "ARG OS_VERSION=(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/docker/library/alpine",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^ubuntu-gha-tools/Dockerfile$"],
+      "matchStrings": [
+        "ARG OS_VERSION=(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/ubuntu/ubuntu",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^playwright/alpine-browsers/Dockerfile\\.glibc-debug$"],
+      "matchStrings": [
+        "ARG UBUNTU_VERSION=(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ubuntu",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^playwright/Dockerfile\\.alpine$"],
+      "matchStrings": [
+        "ARG CHS_REV=(?<currentValue>\\d+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/jclaveau/playwright-alpine-browsers",
+      "extractVersionTemplate": "^chs-(?<version>\\d+)$",
+      "versioningTemplate": "loose"
     }
   ],
   "schedule": [

--- a/tests/aports/test-resolve-aports-ref.sh
+++ b/tests/aports/test-resolve-aports-ref.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Unit test for chromium-headless-shell/scripts/resolve-aports-ref.sh.
+#
+# Happy path: a known-good chromium pkgver resolves to a hex aports SHA.
+# Sad path:   a fabricated pkgver returns "no aports commit found".
+#
+# Network-dependent (hits gitlab.alpinelinux.org).
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT="$HERE/../../playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "FAIL: $SCRIPT not found or not executable" >&2; exit 1; }
+
+echo "=== happy: known pkgver 148.0.7778.96 (versions.env's currently-pinned value) ==="
+SHA=$("$SCRIPT" 148.0.7778.96)
+if [[ ! "$SHA" =~ ^[0-9a-f]{8,}$ ]]; then
+  echo "FAIL: expected hex SHA, got: $SHA" >&2
+  exit 1
+fi
+echo "PASS: $SHA"
+
+echo "=== sad: pkgver 999.0.0.0 (will never exist) ==="
+STDERR=$(mktemp)
+trap 'rm -f "$STDERR"' EXIT
+if "$SCRIPT" 999.0.0.0 2>"$STDERR"; then
+  echo "FAIL: expected non-zero exit on bogus pkgver" >&2
+  exit 1
+fi
+if ! grep -q "no aports commit found" "$STDERR"; then
+  echo "FAIL: stderr missing 'no aports commit found' marker" >&2
+  cat "$STDERR" >&2
+  exit 1
+fi
+echo "PASS: failed loudly as expected"
+
+echo "ALL OK"

--- a/tests/aports/test-versions-env-consistency.sh
+++ b/tests/aports/test-versions-env-consistency.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Consistency guard for playwright/alpine-browsers/versions.env.
+#
+# Asserts ALPINE_APORTS_CHROMIUM_REF points to an aports commit whose
+# community/chromium/APKBUILD pkgver matches PW_VERSION's chromium-headless-shell
+# browserVersion (from playwright-core's browsers.json).
+#
+# Mirrors apply-and-build.sh:43-54's pkgver check at PR time so drift is caught
+# in seconds, not after a 30+ minute producer build.
+#
+# Firefox (ALPINE_APORTS_REF) is INTENTIONALLY NOT checked here — a separate
+# WIP pipeline rebuilds firefox-on-Alpine with PW patches and owns that surface.
+
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+VERSIONS_ENV="$ROOT/playwright/alpine-browsers/versions.env"
+
+[[ -f "$VERSIONS_ENV" ]] || { echo "FAIL: $VERSIONS_ENV not found" >&2; exit 1; }
+
+set -a
+. "$VERSIONS_ENV"
+set +a
+
+: "${PW_VERSION:?versions.env missing PW_VERSION}"
+: "${ALPINE_APORTS_CHROMIUM_REF:?versions.env missing ALPINE_APORTS_CHROMIUM_REF}"
+
+echo "=== PW $PW_VERSION → derive chromium-headless-shell browserVersion ==="
+BROWSERS_JSON=$(curl -fsSL "https://unpkg.com/playwright-core@${PW_VERSION}/browsers.json")
+CHS_VER=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .browserVersion' <<<"$BROWSERS_JSON")
+if [[ -z "$CHS_VER" || "$CHS_VER" == "null" ]]; then
+  echo "FAIL: browsers.json for playwright-core@${PW_VERSION} has no chromium-headless-shell entry" >&2
+  exit 1
+fi
+echo "CHS_VER=$CHS_VER"
+
+echo "=== fetch aports@${ALPINE_APORTS_CHROMIUM_REF} community/chromium/APKBUILD ==="
+APKBUILD=$(curl -fsSL "https://gitlab.alpinelinux.org/alpine/aports/-/raw/${ALPINE_APORTS_CHROMIUM_REF}/community/chromium/APKBUILD")
+PKGVER=$(echo "$APKBUILD" | awk -F= '/^pkgver=/ { gsub(/"/, "", $2); print $2; exit }')
+[[ -n "$PKGVER" ]] || { echo "FAIL: could not parse pkgver from APKBUILD at $ALPINE_APORTS_CHROMIUM_REF" >&2; exit 1; }
+echo "PKGVER=$PKGVER"
+
+if [[ "$PKGVER" != "$CHS_VER" ]]; then
+  echo "FAIL: aports pkgver=$PKGVER but PW pins CHS_VER=$CHS_VER" >&2
+  echo "  Bump ALPINE_APORTS_CHROMIUM_REF in versions.env." >&2
+  echo "  The auto-resolve-aports workflow handles this automatically on Renovate PRs;" >&2
+  echo "  for hand-edited PW bumps, run:" >&2
+  echo "    bash playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh $CHS_VER" >&2
+  exit 2
+fi
+
+echo "PASS: ($PW_VERSION, $ALPINE_APORTS_CHROMIUM_REF) consistent — pkgver=$PKGVER == CHS_VER=$CHS_VER"


### PR DESCRIPTION
## Why

Renovate's existing config silently no-ops on several pins (Dockerfile.alpine ARGs that don't exist) and lets sibling files drift — `playwright/Dockerfile` is at PLAYWRIGHT_VERSION=1.50.1 today while `Dockerfile.alpine`, `versions.env`, and `playwright/package.json` all sit at 1.60.0. Even when Renovate does fire on a PW bump, the alpine-browsers producer build still fails until a human hand-bumps `ALPINE_APORTS_CHROMIUM_REF` — caught only after a 30+ minute compile via `apply-and-build.sh`'s pkgver guard.

This PR closes both gaps. `renovate.json` now bumps the four PW-related pins in one PR, and a new workflow auto-resolves the matching aports chromium SHA in that same PR before CI burns time on a doomed build.

## What's in here

- **`renovate.json`** (commit 1) — drop dead regexes, lock-step grouping for PW + pnpm across all files, new customManagers for OS_VERSION / UBUNTU_VERSION / CHS_REV (GHCR producer tag tracking), drop noisy `pinDigests`.
- **`auto-resolve-aports.yml`** (new) — PR-time workflow: resolve the chromium aports SHA from PW's browsers.json, strict-match pre-flight, commit `[skip ci]` to the PR head ref, or comment-on-failure with the manual fallback.
- **`tests-aports.yml`** + **`tests/aports/`** — unit test for `resolve-aports-ref.sh` and a `(PW_VERSION, ALPINE_APORTS_CHROMIUM_REF)` consistency guard; both pass locally against current `versions.env`.
- **`test-and-publish.yml`** — two-line invariant assertion right after each `pnpm add -D @playwright/test@$PW_VERSION` ensuring the just-installed devDep equals the image's `playwright` CLI version. Makes the consumer-side "matching browsers version" invariant explicit and self-testing.

## Open questions for reviewer

- Should `auto-resolve-aports` trigger only on Renovate PRs (`if: github.event.pull_request.user.login == 'renovate[bot]'`)? Right now it fires on any PR touching versions.env — friendlier for hand-bumps but more surface area for the bot identity.
- The strict-match pre-flight will fail whenever upstream aports' latest chromium APKBUILD is a different dot-release than PW pins. Documented in the workflow header. Worth making `resolve-aports-ref.sh` itself do an exact-match pass instead of prefix-match? I'd defer to the next bump where this actually bites.

## Compatibility

- New workflow needs `contents: write` to push back to PR branches. Renovate PRs are in-repo (Mend App) so default `GITHUB_TOKEN` works.
- Fork-PR contributors: the auto-resolve push will fail (read-only token) — comment-on-failure still works. No regression vs today.
- Loop guard via `if: github.actor != 'github-actions[bot]'` on the job + `[skip ci]` in the workflow's own commits.

## Out of scope

- Firefox-on-Alpine (`ALPINE_APORTS_REF`, firefox apply-and-build majmin check, any firefox consistency test) — a separate WIP pipeline owns that surface.
- Mutating `Dockerfile.alpine`'s `ARG CHS_REV` — already covered by `renovate.json`'s new GHCR customManager.
- Self-hosted Renovate `postUpgradeTasks` — the PR-time workflow approach works with Mend hosted, no infra change.

Assisted-by: Claude:claude-opus-4-7