### PR TITLE
ci(ff): auto-select Dockerfile.iter on push/PR when prebuilt-base exists

### DIFF
--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -192,19 +192,47 @@ jobs:
             type=raw,value=edge,enable=${{ github.event_name != 'pull_request' }}
 
       # Pick between full cold build (Dockerfile, ~2h) and incremental
-      # iteration FROM the prebuilt-base image (Dockerfile.iter, ~5 min). The
-      # prebuilt-base tag must already exist on GHCR for the FF revision PW
-      # resolved above — it's published by the
-      # playwright-alpine-browsers-prebuilt-base.yml workflow.
+      # iteration FROM the prebuilt-base image (Dockerfile.iter, ~5 min).
+      # Selection logic:
+      # - workflow_dispatch use_prebuilt=true  → force iter (explicit override)
+      # - workflow_dispatch use_prebuilt=false → force cold (explicit override)
+      # - PR / push events                     → auto: iter if prebuilt-base-
+      #   ff-${rev} exists on GHCR, else cold. Lets PR iteration loops finish
+      #   in ~10min instead of ~3h, transparently.
+      #
+      # Why not always iter: BuildKit's --mount=type=cache mounts don't export
+      # via cache-to=registry (verified by inspecting the buildcache config —
+      # zero exec.cachemount records). So obj/.mozbuild/sccache go cold every
+      # GHA run. The prebuilt-base path sidesteps that by shipping obj/ as
+      # image layers (cache-from CAN restore those). When prebuilt-base hasn't
+      # been published yet (fresh FF revision), we still need the cold path
+      # once to seed it.
       - id: dockerfile-choice
+        env:
+          BASE_TAG: ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}
         run: |
-          if [ "${{ inputs.use_prebuilt }}" = "true" ]; then
+          choose_iter() {
             echo "file=playwright/alpine-browsers/Dockerfile.iter" >> "$GITHUB_OUTPUT"
-            echo "base=ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}" >> "$GITHUB_OUTPUT"
-          else
+            echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+            echo "::notice::iter path: FROM $BASE_TAG"
+          }
+          choose_cold() {
             echo "file=playwright/alpine-browsers/Dockerfile" >> "$GITHUB_OUTPUT"
             echo "base=" >> "$GITHUB_OUTPUT"
-          fi
+            echo "::notice::cold path: full Dockerfile build (no prebuilt-base for ff-${{ steps.pins.outputs.firefox_revision }})"
+          }
+          case "${{ inputs.use_prebuilt }}" in
+            true)  choose_iter ;;
+            false) choose_cold ;;
+            "")
+              # Auto-select. Pre-flight: does the prebuilt-base tag exist?
+              if docker manifest inspect "$BASE_TAG" >/dev/null 2>&1; then
+                choose_iter
+              else
+                choose_cold
+              fi
+              ;;
+          esac
 
       - name: Build artifact image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Why

Today PR pushes to the FF producer take the full ~3h cold compile, even when `prebuilt-base-ff-\${FF_REV}` is already published on GHCR. The iter path (`Dockerfile.iter`, ~5min) is only reachable via `workflow_dispatch` with `use_prebuilt=true`.

Root cause for the cold-build pain: BuildKit's `cache-to=type=registry,mode=max` doesn't export `--mount=type=cache` content (verified by inspecting the buildcache config blob — 14 records, 0 `exec.cachemount`). So obj/.mozbuild/sccache start empty every GHA run. The `prebuilt-base` path sidesteps that by shipping obj/ as image layers (which `cache-from` CAN restore).

## What

`dockerfile-choice` step:
- workflow_dispatch \`use_prebuilt=true|false\` → explicit override (today's behavior preserved)
- push/PR (\`inputs.use_prebuilt\` empty) → auto-probe with \`docker manifest inspect\`; iter if the tag exists, cold otherwise

Cold remains the seeding path for fresh FF revisions (PW bumps) — once seeded, the [prebuilt-base workflow](.github/workflows/playwright-alpine-browsers-prebuilt-base.yml) publishes a new \`prebuilt-base-ff-\${rev}\` and subsequent PR pushes pick the iter path automatically.

Inline \`::notice::\` makes the chosen path visible at run-level without log-diving.

## Verification

- [ ] PR push with prebuilt-base-ff-1522 already on GHCR → notice says "iter path" → completes ~10min
- [ ] Force a different FF rev where no prebuilt-base exists → notice says "cold path" → falls through to today's behavior
- [ ] workflow_dispatch use_prebuilt=true → still forces iter (no regression)
- [ ] workflow_dispatch use_prebuilt=false → still forces cold (no regression)

## Dependency

Based on PR #49 (\`refactor-extract-bundle-dist\`). Without that, auto-selecting iter would ship bundling-skipped artifacts that segfault on the consumer alpine 3.21 base. Merges cleanly once #49 is in main.

## Out of scope

- Same auto-detect for chromium-headless-shell — the apk fast path is already ~5min, no benefit from a prebuilt-base layer there.
- Auto-publishing prebuilt-base when it's missing (would be slick but cross-workflow dispatch + wait-for-completion is brittle; the current explicit dispatch is the documented seeding flow).

Assisted-by: Claude:claude-opus-4-7