### PR TITLE
alpine consumer: flip Firefox pin from sha tag to ff-1522

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -4,18 +4,13 @@
 # expansion in `COPY --from=` URLs, so we alias the producer-image refs as
 # named build stages and COPY --from that name later.
 ARG CHS_REV=1223
-# Pinned to the producer sha-tag temporarily (PR #44 not yet promoted to
-# ff-${FF_REV}). Flip to ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV}
-# once PR #44 lands and the promote job tags the canonical ff-1522 with the
-# fixed artifact.
 ARG FF_REV=1522
-ARG FF_TAG=sha-03f812dcf9d26729bf7abafd35da78a3a15bcc40
 ARG BASE_IMAGE=jclaveau/alpine-dood-pnpm:latest
 
 # Producer-image stage aliases — Renovate's custom manager bumps the tag
 # revision in lockstep with PLAYWRIGHT_VERSION below.
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} AS chs-source
-FROM ghcr.io/jclaveau/playwright-alpine-browsers:${FF_TAG} AS ff-source
+FROM ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} AS ff-source
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
## Why

In #51 the consumer image was pinned to `sha-03f812dcf9d26729bf7abafd35da78a3a15bcc40` because the canonical `ff-1522` tag still pointed at the pre-fix artifact (it was published by an earlier producer run before #44's exclude-list + ICU-data fix landed). #44 merging triggered the producer's promote job, which retagged `ff-1522` / `ff-141.0` / `ff-latest` to the fixed digest. The sha pin is now redundant.

## What

- Drop the `FF_TAG` ARG entirely (was only used in the `COPY --from` alias).
- Rewrite the alias to `ff-${FF_REV}`, matching the symmetric `chs-${CHS_REV}` form one line up.
- Remove the now-obsolete "temporary sha pin" comment block.

This restores the original Renovate-friendly shape: a single revision ARG that the custom manager bumps in lockstep with `PLAYWRIGHT_VERSION`, instead of needing a parallel FF_TAG update path.

## Verification

The promote job for #44's merge (producer run 26979047061) completed with `promote` succeeding at 03:38:17 of that run. `docker manifest inspect ghcr.io/jclaveau/playwright-alpine-browsers:ff-1522` resolves to the same OCI index this PR now pins.

## Out of scope

- Renovate manager config to bump FF_REV from `versions.env` — separate concern, current CHS_REV pattern likely needs the same treatment too.

Assisted-by: Claude:claude-opus-4-7