### PR TITLE
chore(ci): drop 'musl Firefox build' qualifier from producer workflow name

### DIFF
--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -1,4 +1,4 @@
-name: Playwright Alpine Browsers (musl Firefox build)
+name: Playwright Alpine Browsers
 
 # Producer workflow for the patched-on-musl browser artifact image. Runs on its
 # own cadence — the build is ~1.5–2.5h and only needs to rerun when Playwright


### PR DESCRIPTION
## Why

The workflow name was accurate when the file only built Firefox. Today it also builds chromium-headless-shell (apk fast path) and houses the disabled chromium-from-source + firefox-glibc-debug pipelines. WebKit is next. The 'musl Firefox build' qualifier reads as misleading in the Actions UI.

## What

One-line change to `.github/workflows/playwright-alpine-browsers.yml:1`:

- `name: Playwright Alpine Browsers (musl Firefox build)`
+ `name: Playwright Alpine Browsers`

## Retrocompat

- Sibling workflows keep their qualifying suffixes (`— Prebuilt Base ...`, `— validation ...`) — they describe what each specifically does, distinct from the producer.
- No external references to the display name (greppped READMEs + other workflows). The filename `playwright-alpine-browsers.yml` is unchanged so any `gh workflow run`-style scripts keep working.
- Old run history in the Actions tab will keep showing the old name; only new runs pick up the rename.

## Conflict with #57

Both PRs touch this file. #57 adds the `test_firefox_library_upstream` input + the new job; this PR only changes line 1. Trivial rebase whichever lands first.

Assisted-by: Claude:claude-opus-4-7