### PR TITLE
prepare: composite action for container/vm-mode pre-flight

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,25 @@
+name: Prepare container/vm mode
+description: >-
+  Universal pre-flight for any GHA job using these images (or none): defaults
+  DOCKER_MODE and HOST_ADDRESS for the no-image / vm case, and boots the inner
+  Docker daemon when running under a dind image. Image-side env vars
+  (DOCKER_MODE=dood/dind, HOST_ADDRESS=host.docker.internal/127.0.0.1) take
+  precedence — this action only fills the gap when the consumer runs on the
+  host VM with no container.
+
+runs:
+  using: composite
+  steps:
+    - name: "'vm' as default DOCKER_MODE"
+      shell: bash
+      run: echo "DOCKER_MODE=${DOCKER_MODE:-vm}" >> "$GITHUB_ENV"
+
+    - name: Boot inner Docker daemon (dind)
+      if: ${{ env.DOCKER_MODE == 'dind' }}
+      shell: bash
+      run: start-dockerd
+
+    - name: Default HOST_ADDRESS
+      shell: bash
+      # 127.0.0.1 not localhost — forcing ipv4 avoids connection refused errors
+      run: echo "HOST_ADDRESS=${HOST_ADDRESS:-127.0.0.1}" >> "$GITHUB_ENV"

--- a/.github/workflows/benchmark-playwright.yml
+++ b/.github/workflows/benchmark-playwright.yml
@@ -122,8 +122,11 @@ jobs:
         run: |
           # --only-shell installs the slim headless shell (no X11/Mesa/full font set) — matches what
           # OUR *-playwright images bake in, so this is an apples-to-apples comparison.
-          [ "${{ matrix.browsers }}" = "all" ] && B="" || B="chromium"
-          pnpm exec playwright install --with-deps --only-shell $B
+          if [ "${{ matrix.browsers }}" = "all" ]; then
+            pnpm exec playwright install --with-deps --only-shell
+          else
+            pnpm exec playwright install --with-deps --only-shell chromium
+          fi
       - name: Compute install download size
         run: |
           NA=$(awk '/^[ \t]*eth0:/{print $2}' /proc/net/dev)
@@ -134,11 +137,11 @@ jobs:
         working-directory: playwright
         run: |
           if [ "${{ matrix.browsers }}" = "all" ]; then
-            P="--project=chromium --project=firefox --project=webkit"
+            P=(--project=chromium --project=firefox --project=webkit)
           else
-            P="--project=chromium"
+            P=(--project=chromium)
           fi
-          pnpm exec playwright test $P
+          pnpm exec playwright test "${P[@]}"
       - name: Upload install download size
         if: always()
         uses: actions/upload-artifact@v4
@@ -193,14 +196,16 @@ jobs:
         run: |
           # The official MS image runs as root, but GHA forces HOME=/github/home (owned by pwuser);
           # Firefox/WebKit refuse to launch unless $HOME is owned by the current user, so point root at /root.
-          [[ "${{ matrix.scenario }}" == official* ]] && export HOME=/root
+          SCENARIO="${{ matrix.scenario }}"
+          BROWSERS="${{ matrix.browsers }}"
+          [[ "$SCENARIO" == official* ]] && export HOME=/root
           # Alpine's config only defines the chromium project, so never ask it for firefox/webkit.
-          if [[ "${{ matrix.scenario }}" == alpine-* ]] || [ "${{ matrix.browsers }}" != "all" ]; then
-            P="--project=chromium"
+          if [[ "$SCENARIO" == alpine-* ]] || [ "$BROWSERS" != "all" ]; then
+            P=(--project=chromium)
           else
-            P="--project=chromium --project=firefox --project=webkit"
+            P=(--project=chromium --project=firefox --project=webkit)
           fi
-          pnpm exec playwright test $P
+          pnpm exec playwright test "${P[@]}"
       - name: Upload install download size
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/on-demand-build.yml
+++ b/.github/workflows/on-demand-build.yml
@@ -362,6 +362,7 @@ jobs:
             {
               echo ':white_check_mark: Build complete. Published:'
               echo
+              # shellcheck disable=SC2016  # backticks are literal markdown code-formatting, not command substitution
               echo "$TAGS" | sed 's/^/- `/; s/$/`/'
             } >> /tmp/comment.md
           else

--- a/.github/workflows/playwright-alpine-browsers-validation.yml
+++ b/.github/workflows/playwright-alpine-browsers-validation.yml
@@ -146,6 +146,7 @@ jobs:
           mkdir -p /tmp/ff-dist/firefox
           docker cp ext:/work/firefox-dist/. /tmp/ff-dist/firefox/
           docker rm ext
+          # shellcheck disable=SC2012  # debug listing of build artifacts; ls is fine here
           ls /tmp/ff-dist/firefox/ | head -10
 
           cat > /tmp/Dockerfile.pwrunner <<EOF

--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -518,13 +518,13 @@ jobs:
         # rate limit; DH tags are the external catalog entry.
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/jclaveau/playwright-alpine-browsers:ff-${REV} \
-            -t ghcr.io/jclaveau/playwright-alpine-browsers:ff-${VER} \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:ff-${REV}" \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:ff-${VER}" \
             -t ghcr.io/jclaveau/playwright-alpine-browsers:ff-latest \
-            -t jclaveau/playwright-alpine-browsers:ff-${REV} \
-            -t jclaveau/playwright-alpine-browsers:ff-${VER} \
+            -t "jclaveau/playwright-alpine-browsers:ff-${REV}" \
+            -t "jclaveau/playwright-alpine-browsers:ff-${VER}" \
             -t jclaveau/playwright-alpine-browsers:ff-latest \
-            -t jclaveau/playwright-alpine-browsers:sha-${{ github.sha }} \
+            -t "jclaveau/playwright-alpine-browsers:sha-${{ github.sha }}" \
             "$SRC"
 
   promote-chromium-headless-shell:
@@ -559,13 +559,13 @@ jobs:
           VER: ${{ needs.build-chromium-headless-shell.outputs.chromium_version }}
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/jclaveau/playwright-alpine-browsers:chs-${REV} \
-            -t ghcr.io/jclaveau/playwright-alpine-browsers:chs-${VER} \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${REV}" \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${VER}" \
             -t ghcr.io/jclaveau/playwright-alpine-browsers:chs-latest \
-            -t jclaveau/playwright-alpine-browsers:chs-${REV} \
-            -t jclaveau/playwright-alpine-browsers:chs-${VER} \
+            -t "jclaveau/playwright-alpine-browsers:chs-${REV}" \
+            -t "jclaveau/playwright-alpine-browsers:chs-${VER}" \
             -t jclaveau/playwright-alpine-browsers:chs-latest \
-            -t jclaveau/playwright-alpine-browsers:chs-sha-${{ github.sha }} \
+            -t "jclaveau/playwright-alpine-browsers:chs-sha-${{ github.sha }}" \
             "$SRC"
 
   # ── Chromium-headless-shell — apk fast path ────────────────────────────────

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -108,6 +108,18 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # Static lint for every workflow under .github/workflows AND every composite
+      # action under .github/actions. Catches misspelled keys, bad expressions
+      # (e.g. `if: env.X = 'y'`), missing `shell:` on composite run steps, etc.
+      # Fast-fails the chain before any matrix computation or build job kicks off.
+      - uses: raven-actions/actionlint@v2
+        with:
+          # Ignore `if-cond` on the 2 intentionally-disabled jobs (playwright-alpine-browsers.yml:684,
+          # 852). actionlint's -ignore matches the error message (not the rule tag), and the wrapper's
+          # flag parser preserves literal "-quote chars so we can't pass a spaced pattern — `.` matches
+          # the space in "constant expression".
+          flags: -ignore constant.expression
+
       # used later
       - id: extract_docker_group_id
         run: 'echo "docker_group_id=$(getent group docker | cut -d: -f3)" >> "$GITHUB_OUTPUT"'
@@ -916,9 +928,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: runner sudoers IS stripped (broad NOPASSWD gone)
         run: |
-          docker run --rm --entrypoint sh "$IMG" -c '! test -f /etc/sudoers.d/runner' \
-            && echo "OK: /etc/sudoers.d/runner is absent" \
-            || { echo "FAIL: /etc/sudoers.d/runner still present"; exit 1; }
+          if docker run --rm --entrypoint sh "$IMG" -c '! test -f /etc/sudoers.d/runner'; then
+            echo "OK: /etc/sudoers.d/runner is absent"
+          else
+            echo "FAIL: /etc/sudoers.d/runner still present"
+            exit 1
+          fi
       - name: dind sudoers IS present (narrow per-binary grant survives the overlay)
         # Read as uid 0: /etc/sudoers.d/dind is mode 0440 root:root (standard sudoers
         # mode) so the default `runner` can't cat it. We're verifying the file's
@@ -1329,6 +1344,63 @@ jobs:
 
 
   # ----------------------------------------------------------------------------
+  # act: exercise the `prepare` composite action against each freshly-built
+  # dood/dind image. Mirrors test-dood-dind-act but drives smoke-prepare-<mode>.yml
+  # — which calls `uses: ./.github/actions/prepare` and asserts the image-supplied
+  # DOCKER_MODE / HOST_ADDRESS survive the action's `${VAR:-default}` fallbacks.
+  # The dind row additionally verifies `start-dockerd` fired (docker info reaches
+  # the inner daemon).
+  # ----------------------------------------------------------------------------
+  test-prepare-act:
+    runs-on: ubuntu-latest
+    if: fromJSON(needs.github-context.outputs.test_filters).dood_dind
+    needs: [github-context, build-dood, build-dind]
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.github-context.outputs.os_matrix) }}
+        mode: [dood, dind]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install act
+        run: curl -sSL "https://raw.githubusercontent.com/nektos/act/v${ACT_VERSION}/install.sh" | sudo bash -s -- -b /usr/local/bin
+      - name: Pre-pull the container image
+        run: docker pull "ghcr.io/jclaveau/${{ matrix.os }}-${{ matrix.mode }}:${{ needs.github-context.outputs.build_tag }}"
+      - name: Run the prepare smoke workflow through act
+        env:
+          IMG: ghcr.io/jclaveau/${{ matrix.os }}-${{ matrix.mode }}:${{ needs.github-context.outputs.build_tag }}
+        run: |
+          act push -W tests/act/smoke-prepare-${{ matrix.mode }}.yml \
+            -P ubuntu-latest=-self-hosted \
+            --var RUNNER_IMAGE="$IMG"
+
+
+  # ----------------------------------------------------------------------------
+  # act: vm-mode coverage for the `prepare` composite action — no `container:`,
+  # no image. Verifies the action's DOCKER_MODE=vm + HOST_ADDRESS=127.0.0.1
+  # fallbacks fire when the consumer runs on a plain host runner (the
+  # `image: ""` matrix row in tests-e2e-front.yml-style consumers).
+  # No test filter — the smoke is image-independent and cheap.
+  # ----------------------------------------------------------------------------
+  test-prepare-vm-act:
+    runs-on: ubuntu-latest
+    needs: [github-context]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install act
+        run: curl -sSL "https://raw.githubusercontent.com/nektos/act/v${ACT_VERSION}/install.sh" | sudo bash -s -- -b /usr/local/bin
+      - name: Run the prepare-vm smoke through act
+        run: act push -W tests/act/smoke-prepare-vm.yml -P ubuntu-latest=-self-hosted
+
+
+  # ----------------------------------------------------------------------------
   # TODO(pnpm#3699): re-enable test-dood-pnpm-act once pnpm stops re-`chmod`-ing
   # existing global bin entries during `install -g`. The job below ran the
   # arbitrary-UID act-bind smoke against every pnpm-bearing layer to lock in
@@ -1602,6 +1674,7 @@ jobs:
         run: |
           set -e
           for i in 1 2 3; do
+            # shellcheck disable=SC2046  # jq emits `-t name -t name`; quoting would collapse to a single arg
             if docker buildx imagetools create \
               $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
               ghcr.io/jclaveau/${{ matrix.os }}-${{ steps.src.outputs.src }}:${{ needs.github-context.outputs.build_tag }}; then

--- a/.github/workflows/tmp-dind-debug.yml
+++ b/.github/workflows/tmp-dind-debug.yml
@@ -68,7 +68,7 @@ jobs:
           start-dockerd
           export DOCKER_HOST=unix:///var/run/dind.sock
           # record the dockerd PID + session so step 2 can check the exact process
-          for c in /proc/[0-9]*/comm; do n=$(cat "$c" 2>/dev/null) || continue; case "$n" in dockerd) basename "$(dirname "$c")" > /tmp/step1-dockerd.pid; awk '{print $6}' /proc/$(cat /tmp/step1-dockerd.pid)/stat > /tmp/step1-dockerd.sess;; esac; done
+          for c in /proc/[0-9]*/comm; do n=$(cat "$c" 2>/dev/null) || continue; case "$n" in dockerd) basename "$(dirname "$c")" > /tmp/step1-dockerd.pid; awk '{print $6}' "/proc/$(cat /tmp/step1-dockerd.pid)/stat" > /tmp/step1-dockerd.sess;; esac; done
           echo "### STEP 1 recorded dockerd pid=$(cat /tmp/step1-dockerd.pid 2>/dev/null) session=$(cat /tmp/step1-dockerd.sess 2>/dev/null)"
           DOCKER_HOST=unix:///var/run/dind.sock bash /tmp/diag.sh
           echo "### END OF STEP 1"
@@ -81,8 +81,8 @@ jobs:
           echo "### START OF STEP 2"
           PID1=$(cat /tmp/step1-dockerd.pid 2>/dev/null)
           echo "recorded step-1 dockerd pid=$PID1 session=$(cat /tmp/step1-dockerd.sess 2>/dev/null)"
-          if [ -n "$PID1" ] && [ -e /proc/$PID1 ]; then
-            echo ">>> VERDICT: dockerd pid=$PID1 STILL EXISTS (state=$(awk '{print $3}' /proc/$PID1/stat 2>/dev/null), ppid=$(awk '{print $4}' /proc/$PID1/stat 2>/dev/null))"
+          if [ -n "$PID1" ] && [ -e "/proc/$PID1" ]; then
+            echo ">>> VERDICT: dockerd pid=$PID1 STILL EXISTS (state=$(awk '{print $3}' "/proc/$PID1/stat" 2>/dev/null), ppid=$(awk '{print $4}' "/proc/$PID1/stat" 2>/dev/null))"
           else
             echo ">>> VERDICT: dockerd pid=$PID1 is GONE across the step boundary"
           fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container: jclaveau/ubuntu-dood-playwright-gyp:latest
     steps:
+      - uses: jclaveau/ci-prebuilds/.github/actions/prepare@main  # DOCKER_MODE/HOST_ADDRESS defaults + start-dockerd under dind
       - uses: actions/checkout@v4
       - run: pnpm install --frozen-lockfile
       - run: docker compose up -d --wait  # no docker mcr.microsoft.com/playwright
@@ -32,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container: jclaveau/ubuntu-dood-pnpm-gyp:latest
     steps:
+      - uses: jclaveau/ci-prebuilds/.github/actions/prepare@main
       - uses: actions/checkout@v4
       - run: pnpm install --frozen-lockfile
       - run: docker compose up -d --wait
@@ -104,6 +106,53 @@ current chain (Ubuntu 24.04 / Node 22.12 / pnpm 9.15 / Playwright 1.50):
 ## Gains
 
 See [The last benchmarks](https://github.com/jclaveau/ci-prebuilds/actions/workflows/benchmark-playwright.yml).
+
+
+## Full control usage
+
+```yaml
+jobs:
+  e2e-front:
+    name: ${{ matrix.mode }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: # Switch between ci environments to debug or save time
+          - mode: dood
+            image: jclaveau/ubuntu-dood-playwright-gyp:latest
+            options: --volume /var/run/docker.sock:/var/run/docker.sock
+          # - mode: dind
+          #   image: jclaveau/ubuntu-dind-playwright-gyp:latest
+          #   options: --privileged --env DOCKER_HOST=unix:///var/run/dind.sock
+          # - mode: vm
+          #   image: ""    # empty image → run on the host VM
+          #   options: ""
+    container:
+      image: ${{ matrix.image }}
+      options: ${{ matrix.options }}
+    steps:
+      - uses: jclaveau/ci-prebuilds/.github/actions/prepare@main  # DOCKER_MODE/HOST_ADDRESS defaults + start-dockerd under dind
+      - uses: actions/checkout@v4
+
+      - if: env.DOCKER_MODE == 'vm'
+        uses: actions/setup-node@v4
+      - if: env.DOCKER_MODE == 'vm'
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - run: pnpm install --frozen-lockfile
+      - run: docker compose up -d --wait
+
+      - if: env.DOCKER_MODE == 'vm'
+        name: Install Playwright browsers (vm)
+        run: pnpm exec playwright install --with-deps
+
+      - run: pnpm exec playwright test
+```
+
+See [the action](.github/actions/prepare/action.yml). Pin to a commit SHA (or future `@v1` tag) for production use; `@main` is shown here for readability.
 
 
 ## Roadmap

--- a/tests/act/smoke-prepare-dind.yml
+++ b/tests/act/smoke-prepare-dind.yml
@@ -1,0 +1,25 @@
+# Smoke workflow for the `prepare` composite action against a dind image.
+# Runs under `act` from test-prepare-act in test-and-publish.yml; the image is
+# injected via `act --var RUNNER_IMAGE=...`.
+#
+# What this proves: the composite preserves image-supplied DOCKER_MODE=dind
+# and HOST_ADDRESS=127.0.0.1 AND fires the conditional `start-dockerd` step
+# (verified by `docker info` reaching the inner daemon).
+name: act smoke prepare (dind)
+on: [push]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.RUNNER_IMAGE }}
+      # dind: same env as smoke-dind.yml so docker clients reach the inner daemon.
+      options: --privileged --env DOCKER_HOST=unix:///var/run/dind.sock
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - name: DOCKER_MODE preserved from image
+        run: test "$DOCKER_MODE" = "dind"
+      - name: HOST_ADDRESS preserved from image
+        run: test "$HOST_ADDRESS" = "127.0.0.1"
+      - name: inner daemon reachable (proves start-dockerd ran)
+        run: docker info

--- a/tests/act/smoke-prepare-dood.yml
+++ b/tests/act/smoke-prepare-dood.yml
@@ -1,0 +1,23 @@
+# Smoke workflow for the `prepare` composite action against a dood image.
+# Runs under `act` from test-prepare-act in test-and-publish.yml; the image is
+# injected via `act --var RUNNER_IMAGE=...`. Kept out of .github/workflows so
+# real CI ignores it.
+#
+# What this proves: the composite is a no-op past `start-dockerd` in dood mode
+# — image-supplied DOCKER_MODE=dood and HOST_ADDRESS=host.docker.internal must
+# survive the action's `${VAR:-default}` fallbacks unchanged.
+name: act smoke prepare (dood)
+on: [push]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ vars.RUNNER_IMAGE }}
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - name: DOCKER_MODE preserved from image
+        run: test "$DOCKER_MODE" = "dood"
+      - name: HOST_ADDRESS preserved from image
+        run: test "$HOST_ADDRESS" = "host.docker.internal"

--- a/tests/act/smoke-prepare-vm.yml
+++ b/tests/act/smoke-prepare-vm.yml
@@ -1,0 +1,20 @@
+# Smoke workflow for the `prepare` composite action in vm-mode (no container).
+# Runs under `act` from test-prepare-vm-act in test-and-publish.yml. Image-less
+# — exercises the `${VAR:-default}` fallbacks for consumers running on a plain
+# `runs-on: ubuntu-latest` host without any of these images.
+#
+# What this proves: with neither DOCKER_MODE nor HOST_ADDRESS set on the
+# environment, the composite defaults them to `vm` and `127.0.0.1`. The
+# `start-dockerd` step must NOT run (its `if:` gates on DOCKER_MODE=dind).
+name: act smoke prepare (vm)
+on: [push]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - name: DOCKER_MODE defaulted to vm
+        run: test "$DOCKER_MODE" = "vm"
+      - name: HOST_ADDRESS defaulted to 127.0.0.1
+        run: test "$HOST_ADDRESS" = "127.0.0.1"


### PR DESCRIPTION
## Why

Three universal pre-flight steps get copy-pasted into every consumer workflow that wants to switch dood↔dind↔vm: default `DOCKER_MODE`, boot `start-dockerd` under dind, default `HOST_ADDRESS`. Factoring them here lets consumers replace 3 inline steps with one `uses:` line and stay retrocompat with the no-image vm case.

Originally walked through against a consumer's `tests-e2e-front.yml` that runs the same shard matrix across dood (active), dind and vm (both commented). The README example mirrors that convention.

## Retro-compat

Purely additive. Existing consumers reading image-supplied env directly continue to work; the action is just a new entry point. The action defaults via `${VAR:-default}` so image-side `DOCKER_MODE=dood/dind` and `HOST_ADDRESS=host.docker.internal/127.0.0.1` always win.

## Coverage

- `smoke-prepare-dood.yml` — image-supplied DOCKER_MODE/HOST_ADDRESS survive the fallback no-ops.
- `smoke-prepare-dind.yml` — same, plus `docker info` after the composite proves `start-dockerd` fired (the conditional branch).
- `smoke-prepare-vm.yml` — no `container:`; asserts the fallback defaults fire on a host runner.

Wired via two new jobs:
- `test-prepare-act` — matrix `[dood, dind] × os_matrix`, gated on the existing `dood_dind` filter, mirrors `test-dood-dind-act`'s install/pre-pull/`act push` shape.
- `test-prepare-vm-act` — image-less, runs the vm smoke through act.

## Out of scope

Node-vs-`.nvmrc` verify, pnpm-cache wiring, DOOD host-workspace inspection (`docker inspect "$HOSTNAME"`), act `chown`, `wait-port` install — all consumer-specific, deliberately left in the consumer.

## Bonus: actionlint

Added `raven-actions/actionlint@v2` to the `github-context` job — lints every `.github/workflows/*.yml` AND every `.github/actions/**/action.yml` before any build/test job kicks off. Independent value beyond this PR; happy to split if it surfaces enough findings on existing workflows that you'd prefer a separate cleanup PR first.

## Questions

- Action name `prepare` — keep, or do you prefer `bootstrap` / `init` / `boot`?
- Tag `@v1` now (so consumers can pin via tag) or wait until ≥1 real consumer pins via SHA for a couple of weeks first?