### PR TITLE
ci(firefox): content-address prebuilt-base on the patch set, not just PW rev

### DIFF
--- a/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
+++ b/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
@@ -56,6 +56,19 @@ jobs:
           echo "firefox_revision=$REV" >> "$GITHUB_OUTPUT"
           echo "firefox_version=$VER" >> "$GITHUB_OUTPUT"
           echo "PW v${PW_VERSION} → firefox revision=${REV} browserVersion=${VER}"
+          # Patch-set hash — MUST match playwright-alpine-browsers.yml's pins step
+          # (the consumer's auto-select checks prebuilt-base-ff-<rev>-<hash>). Same
+          # file list = same tag, so a source-only patch reseeds the base instead
+          # of silently reusing a stale one. Excludes apply-and-build-iter.sh.
+          PATCHSET_HASH=$(cat \
+            playwright/alpine-browsers/versions.env \
+            playwright/alpine-browsers/firefox/scripts/apply-and-build.sh \
+            playwright/alpine-browsers/firefox/scripts/fetch-aports.sh \
+            playwright/alpine-browsers/firefox/scripts/fetch-pw-patches.sh \
+            playwright/alpine-browsers/firefox/mozconfig.overlay \
+            | sha256sum | cut -c1-12)
+          echo "patchset_hash=$PATCHSET_HASH" >> "$GITHUB_OUTPUT"
+          echo "FF patch-set hash=${PATCHSET_HASH}"
 
       - name: Free up runner disk (FF source + obj dir is ~15 GB)
         run: |
@@ -78,7 +91,10 @@ jobs:
           context: playwright/alpine-browsers
           file: playwright/alpine-browsers/Dockerfile.prebuilt-base
           push: true
+          # The hashed tag is the one the consumer auto-select consumes; the
+          # rev-only + latest tags stay as human-readable aliases (not consumed).
           tags: |
+            ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}-${{ steps.pins.outputs.patchset_hash }}
             ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}
             ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-latest
           # Dedicated registry cache for the prebuilt-base lineage — separate

--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -250,6 +250,22 @@ jobs:
           echo "firefox_revision=$REV" >> "$GITHUB_OUTPUT"
           echo "firefox_version=$VER" >> "$GITHUB_OUTPUT"
           echo "PW v${PW_VERSION} → firefox revision=${REV} browserVersion=${VER}"
+          # Content-address the prebuilt-base on the FF patch SET, not just PW's
+          # rev. A source-only patch (e.g. the Juggler location fix in
+          # apply-and-build.sh) leaves the rev unchanged, so a rev-only base tag
+          # lets the iter path reuse a stale pre-patch base and ship an unpatched
+          # ff-latest (shipped exactly that 2026-07-28). Hashing the files baked
+          # INTO the base forces a cold reseed whenever the patch set changes.
+          # Excludes apply-and-build-iter.sh (applied at iter time, not baked in).
+          PATCHSET_HASH=$(cat \
+            playwright/alpine-browsers/versions.env \
+            playwright/alpine-browsers/firefox/scripts/apply-and-build.sh \
+            playwright/alpine-browsers/firefox/scripts/fetch-aports.sh \
+            playwright/alpine-browsers/firefox/scripts/fetch-pw-patches.sh \
+            playwright/alpine-browsers/firefox/mozconfig.overlay \
+            | sha256sum | cut -c1-12)
+          echo "patchset_hash=$PATCHSET_HASH" >> "$GITHUB_OUTPUT"
+          echo "FF patch-set hash=${PATCHSET_HASH}"
 
       - name: Free up runner disk (FF source + obj dir is ~15 GB)
         run: |
@@ -281,8 +297,8 @@ jobs:
       # - workflow_dispatch use_prebuilt=true  → force iter (explicit override)
       # - workflow_dispatch use_prebuilt=false → force cold (explicit override)
       # - PR / push events                     → auto: iter if prebuilt-base-
-      #   ff-${rev} exists on GHCR, else cold. Lets PR iteration loops finish
-      #   in ~10min instead of ~3h, transparently.
+      #   ff-${rev}-${patchset_hash} exists on GHCR, else cold. Lets PR iteration
+      #   loops finish in ~10min instead of ~3h, transparently.
       #
       # Why not always iter: BuildKit's --mount=type=cache mounts don't export
       # via cache-to=registry (verified by inspecting the buildcache config —
@@ -293,7 +309,7 @@ jobs:
       # once to seed it.
       - id: dockerfile-choice
         env:
-          BASE_TAG: ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}
+          BASE_TAG: ghcr.io/jclaveau/playwright-alpine-browsers:prebuilt-base-ff-${{ steps.pins.outputs.firefox_revision }}-${{ steps.pins.outputs.patchset_hash }}
         run: |
           choose_iter() {
             echo "file=playwright/alpine-browsers/Dockerfile.iter" >> "$GITHUB_OUTPUT"
@@ -303,7 +319,7 @@ jobs:
           choose_cold() {
             echo "file=playwright/alpine-browsers/Dockerfile" >> "$GITHUB_OUTPUT"
             echo "base=" >> "$GITHUB_OUTPUT"
-            echo "::notice::cold path: full Dockerfile build (no prebuilt-base for ff-${{ steps.pins.outputs.firefox_revision }})"
+            echo "::notice::cold path: full Dockerfile build (no prebuilt-base for ff-${{ steps.pins.outputs.firefox_revision }}-${{ steps.pins.outputs.patchset_hash }})"
           }
           case "${{ inputs.use_prebuilt }}" in
             true)  choose_iter ;;


### PR DESCRIPTION
## Why

The merge to main (540234e) promoted an **unpatched** `ff-latest`. I only caught it by extracting `omni.ja` from the promoted image and diffing the Juggler protocol: `ff-latest` (BuildID `20260728082355`) has `uncaughtError: { frameId, message, stack }` — no `location` — while the branch build `sha-ef541ad` (BuildID `20260720131406`) has `location: runtimeTypes.ScriptLocation`. So every `ff-latest` consumer still crashes `Cannot read properties of undefined (reading 'url')` on pageerror (headed FF conformance + the whole pageerror family). The self-heal I expected from the merge silently didn't happen.

Root cause: the `prebuilt-base-ff` image is tagged **only** on PW's pinned Firefox revision. The 2026-07-20 Juggler `location` patch lives in `apply-and-build.sh` and doesn't change that revision, so `build-firefox`'s auto-select saw the pre-patch base "exists", chose the iter path, and repackaged the pre-patch juggler with a fresh BuildID. `build-firefox` was 6 min on the merge (a warm iter), not the ~3h a real recompile would take — the tell.

## What

Content-address the base on the **patch set**, not just the rev. Hash the files baked into the base — `versions.env`, `apply-and-build.sh`, `fetch-aports.sh`, `fetch-pw-patches.sh`, `mozconfig.overlay` — into a 12-char sha256 prefix and tag `prebuilt-base-ff-<rev>-<hash>`. Producer (`…-prebuilt-base.yml`) and consumer (`…-browsers.yml`) compute the identical hash from the checked-out files, so they agree with zero coordination. Any patch-set change → new hash → auto-select misses → cold reseed → fresh base carries the patch → iter inherits. The trap becomes structurally impossible and the patch stays single-source in `apply-and-build.sh` (no duplicating it into the iter script).

## Deliberately out of scope

- `apply-and-build-iter.sh` is **excluded** from the hash: it runs at iter time, not baked into the base, so hashing it would force needless ~3h base rebuilds.
- The rev-only + `ff-latest` base tags stay as human aliases — no longer consumed by auto-select, kept for readability. Happy to drop them if you'd rather not have dangling aliases.
- This PR does **not** reseed `ff-latest`. That's a manual dispatch after merge (the base workflow is dispatch-only): dispatch `prebuilt-base` (~3h, seeds `-<hash>`), then `build-firefox` auto-iters (~5min) → patched `ff-latest`.

## Questions for you

- The reseed costs one ~3h cold FF compile (inherent — the pre-patch base must recompile with the patch). Warm `sccache`/`buildcache-prebuilt` may cut it well under. OK to eat that once?
- Want me to also add the same patch-set hashing to the chromium/webkit prebuilt-base lineages, or is FF the only one with this rev-vs-patchset split? (Haven't audited the others yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Audit result — other browsers are SAFE (answers Q2)

Audited chromium (apk / from-source rounds / headed rounds) and webkit (source-prep + wpe/gtk rounds). **This bug class exists in exactly one place: the FF iter path's `docker manifest inspect "$BASE_TAG"` auto-select — the thing this PR fixes.** No chromium/webkit analog.

Why they're immune: neither added an iter/prebuilt-base fast-path. All heavy work is split into `*-sha-${{ github.sha }}` rounds, unconditionally rebuilt per dispatch (job gates are event/label-based, never existence-based). Source patch → new commit → new sha → fresh tag namespace, zero reuse path. Promotes (`chs-${rev}`, `wk-${rev}`) always `imagetools create` FROM the fresh-sha image. The one moving cache (`buildcache-wk-src`) is a normal BuildKit layer cache with COPY-before-RUN, so a source patch invalidates it. Consumer-side `manifest inspect` calls (`on-demand-build.yml`, `smoke-webkit-iter.yml`, `benchmark-playwright.yml`) are assertions / byte-size reads, not reuse-skips.

So this PR closes the only instance — no follow-up needed for the other pipelines.
