### PR TITLE
ci(chromium): promote from-source → chs-<rev> (retag existing, no rebuild)

### DIFF
--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -864,13 +864,18 @@ jobs:
     secrets: inherit
 
   promote-chromium-headless-shell:
-    # Parallel promote for the apk-fast-path chromium artifact. Same dual-
-    # target shape as FF promote: GHCR for CI consumption, DH for external.
+    # Promote for the apk-fast-path chromium artifact into an ISOLATED
+    # `chs-apk-<rev>` namespace — it does NOT own the canonical consumer tags
+    # `chs-<rev>` / `chs-latest` (those belong to the conformance-grade
+    # from-source build, promoted by promote-chromium-from-source.yml). apk is
+    # SUPERSEDED + conformance-limited (task #13); keeping it on a separate
+    # namespace means exercising the escape hatch can never clobber the
+    # from-source chs-<rev> the alpine-*-playwright consumer COPYs.
     # Triggers:
-    # - push to main (canonical promotion path; uses versions.env default PW)
+    # - push to main (uses versions.env default PW)
     # - workflow_dispatch with build_chromium_headless_shell=true (on-demand
     #   catalog accumulation: dispatcher can pass pw_version to publish the
-    #   chs-${rev} tag matching a non-default PW pin)
+    #   chs-apk-${rev} tag matching a non-default PW pin)
     needs: [build-chromium-headless-shell, smoke-chromium-headless-shell, conformance-chromium-headless-shell]
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
@@ -888,19 +893,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Promote chromium-headless-shell → GHCR + Docker Hub
+      - name: Promote chromium-headless-shell (apk) → chs-apk-<rev> (GHCR + Docker Hub)
+        # ISOLATED namespace — NOT chs-<rev>/chs-latest (those are from-source's,
+        # see promote-chromium-from-source.yml). Prevents the superseded apk path
+        # from clobbering the conformance-grade chromium the consumer COPYs.
         env:
           SRC: ghcr.io/jclaveau/playwright-alpine-browsers:chs-sha-${{ github.sha }}
           REV: ${{ needs.build-chromium-headless-shell.outputs.chromium_revision }}
           VER: ${{ needs.build-chromium-headless-shell.outputs.chromium_version }}
         run: |
           docker buildx imagetools create \
-            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${REV}" \
-            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${VER}" \
-            -t ghcr.io/jclaveau/playwright-alpine-browsers:chs-latest \
-            -t "jclaveau/playwright-alpine-browsers:chs-${REV}" \
-            -t "jclaveau/playwright-alpine-browsers:chs-${VER}" \
-            -t jclaveau/playwright-alpine-browsers:chs-latest \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-apk-${REV}" \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-apk-${VER}" \
+            -t "jclaveau/playwright-alpine-browsers:chs-apk-${REV}" \
+            -t "jclaveau/playwright-alpine-browsers:chs-apk-${VER}" \
             -t "jclaveau/playwright-alpine-browsers:chs-sha-${{ github.sha }}" \
             "$SRC"
 

--- a/.github/workflows/promote-chromium-from-source.yml
+++ b/.github/workflows/promote-chromium-from-source.yml
@@ -1,0 +1,90 @@
+name: Promote chromium-from-source → chs-<rev>
+
+# Promotes an ALREADY-BUILT from-source chromium-headless-shell image (chs-fs-*)
+# to the canonical consumer tags chs-<rev> / chs-<version> / chs-latest on both
+# GHCR and Docker Hub — a pure imagetools retag, NO rebuild. The from-source
+# build is the conformance-grade one (the apk fast-path is SUPERSEDED and its
+# chs-<rev> promote is gated off on push); this makes chs-<rev> point at
+# from-source so the alpine-*-playwright consumer (which COPYs chs-<rev>) ships
+# conformance-grade chromium.
+#
+# Reuse-if-exists: because it retags an existing chs-fs image, re-running per PW
+# rev costs seconds. Dispatch it after a from-source build lands (or to promote
+# the current chs-fs-edge). Conformance for the promoted build must be verified
+# out-of-band before dispatching (the from-source pipeline's conformance job, or
+# a triage of the build's last conformance run).
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        description: Existing from-source image tag to promote (e.g. chs-fs-edge or chs-fs-sha-<sha>)
+        default: chs-fs-edge
+        type: string
+      pw_version:
+        description: Playwright version whose chromium revision/version tags to write
+        default: '1.60.0'
+        type: string
+
+concurrency:
+  group: promote-chromium-from-source
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve chromium rev/version from PW browsers.json
+        id: pins
+        env:
+          PW: ${{ inputs.pw_version }}
+        run: |
+          BJ=$(curl -sL --fail "https://cdn.jsdelivr.net/npm/playwright-core@${PW}/browsers.json") \
+            || { echo "::error::could not fetch browsers.json for PW ${PW}"; exit 1; }
+          REV=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .revision' <<<"$BJ")
+          VER=$(jq -r '.browsers[] | select(.name=="chromium-headless-shell") | .browserVersion' <<<"$BJ")
+          if [ -z "$REV" ] || [ "$REV" = "null" ]; then
+            echo "::error::failed to resolve chromium-headless-shell revision"; exit 1
+          fi
+          echo "rev=$REV" >> "$GITHUB_OUTPUT"
+          echo "ver=$VER" >> "$GITHUB_OUTPUT"
+          echo "PW ${PW} → chromium-headless-shell rev=${REV} version=${VER}"
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pre-flight — source from-source image must exist
+        env:
+          SRC: ghcr.io/jclaveau/playwright-alpine-browsers:${{ inputs.source_tag }}
+        run: |
+          docker manifest inspect "$SRC" >/dev/null \
+            || { echo "::error::source image $SRC not found on GHCR"; exit 1; }
+          echo "source OK: $SRC"
+
+      - name: Promote from-source → chs-<rev> (GHCR + Docker Hub)
+        env:
+          SRC: ghcr.io/jclaveau/playwright-alpine-browsers:${{ inputs.source_tag }}
+          REV: ${{ steps.pins.outputs.rev }}
+          VER: ${{ steps.pins.outputs.ver }}
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${REV}" \
+            -t "ghcr.io/jclaveau/playwright-alpine-browsers:chs-${VER}" \
+            -t ghcr.io/jclaveau/playwright-alpine-browsers:chs-latest \
+            -t "jclaveau/playwright-alpine-browsers:chs-${REV}" \
+            -t "jclaveau/playwright-alpine-browsers:chs-${VER}" \
+            -t jclaveau/playwright-alpine-browsers:chs-latest \
+            "$SRC"
+          echo "::notice::promoted $SRC → chs-${REV} / chs-${VER} / chs-latest (from-source, conformance-grade)"


### PR DESCRIPTION
The `alpine-*-playwright` consumer COPYs `chs-<rev>` (`chs-1223`). That tag was owned by the **apk** promote — but apk is SUPERSEDED + conformance-limited (task #13 UA-stylesheet), so `chs-1223` was stale apk. The conformance-grade **from-source** build sits at `chs-fs-*` and never reached `chs-<rev>`.

This PR:
- **Adds** `promote-chromium-from-source.yml` — a `workflow_dispatch` that **imagetools-retags an existing from-source image** (`chs-fs-edge` / `chs-fs-sha-*`) → `chs-<rev>` / `chs-<version>` / `chs-latest` on GHCR + Docker Hub. Pure retag, **no rebuild** (the from-source binary already exists), re-runnable per PW rev (resolves rev/version from PW `browsers.json`).
- **Retires** the apk `promote-chromium-headless-shell` to an isolated `chs-apk-<rev>` namespace (drops `chs-latest`). So `chs-<rev>`/`chs-latest` now have **exactly one writer** — the from-source promoter — and exercising the apk escape hatch can never clobber it.

**Conformance triage (this session):** `chs-fs-edge` (`4896358e`) had one red — `oopif re-connect CDP`, a PW-intended full-chrome test now title-skipped on main; binary clean. `ff-1522` (today's `0baf9cec`, location-patch present) and `wk-2287` (07-22, post-fix) also clear.

After merge I'll dispatch it (`source_tag=chs-fs-edge`, `pw_version=1.60.0`) to make `chs-1223` = from-source, then rebuild the consumer so the shipped images carry conformance-grade chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
