### PR TITLE
fix(playwright-alpine): from-source chromium's shared runtime deps (libxslt/double-conversion/minizip/crc32c)

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -114,10 +114,13 @@ RUN sudo touch /ms-playwright/webkit-${WK_REV}/INSTALLATION_COMPLETE \
 # image README) — the two are required together (see the producer Tier-2 smoke).
 ENV WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
 
-# Runtime libs. chromium-headless-shell is RPATH=$ORIGIN self-contained,
-# Firefox bundles its peer .so + ICU data but still needs the universal-
-# runtime libs (libstdc++, libgcc_s, musl) to resolve from the consumer
-# base. WebKit-WPE loads libwpe + GTK4 + a full gstreamer stack at runtime.
+# Runtime libs. chromium-headless-shell has RPATH=$ORIGIN but the FROM-SOURCE
+# build (unlike the old apk one) is NOT fully self-contained — it dynamically
+# links Alpine's libxslt + double-conversion + minizip + crc32c (aports chromium
+# builds these use_system_*), so the consumer must supply them or the binary
+# dies at load with `Error relocating … symbol not found`. Firefox bundles its
+# peer .so + ICU data but still needs the universal runtime libs (libstdc++,
+# libgcc_s, musl). WebKit-WPE loads libwpe + GTK4 + a full gstreamer stack.
 # Apk list union of aports' community/chromium + community/firefox `depends=`
 # plus the WebKit deps proven by the producer Tier-2 smoke, trimmed to what
 # headless actually loads.
@@ -131,4 +134,5 @@ RUN sudo apk add --no-cache \
         mesa-gles mesa-gbm mesa-dri-gallium mesa-vulkan-swrast \
         gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav \
         opus libsecret \
+        libxslt double-conversion minizip crc32c \
  && pnpm install -g playwright@${PLAYWRIGHT_VERSION}


### PR DESCRIPTION
**Regression from #85.** Promoting from-source into `chs-1223` broke the consumer chromium — `test-playwright-usage (alpine)` failed with:
```
Error relocating …/chrome-headless-shell: xsltNewSecurityPrefs: symbol not found
… double_conversion::… / unz*/zip* (minizip) / crc32c::Extend: symbol not found
```

The **apk** chromium-headless-shell was self-contained (bundled its .so via `RPATH=$ORIGIN`). The **from-source** build instead dynamically links Alpine's `libxslt`, `double-conversion`, `minizip`, `crc32c` (aports chromium builds these `use_system_*`). The consumer apk list didn't supply them.

Enumerated the full set by `ldd`'ing the from-source binary against the consumer base + current deps — exactly those four resolve it (verified blank `ldd`). Alpine versions match (from-source built on aports), so no drift.

- firefox + webkit unaffected (only chromium failed).
- The broken build **did not publish** (`aggregate-tags` skipped on the failed test) — `:latest` still carries the prior working image. No regression shipped.

After merge, the consumer rebuild picks up from-source `chs-1223` **with** these deps → conformance-grade chromium that actually launches. I'll verify the shipped `:latest` chromium version post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)