### PR TITLE
perf(playwright): slim combined image — drop headed WebKit gtk, strip from-source chromium

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -99,12 +99,20 @@ RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
   | sudo tee /ms-playwright/firefox-${FF_REV}/firefox/firefox >/dev/null \
  && sudo chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox
 
-# WebKit — musl-built WPE (headless) + GTK (headed) MiniBrowser, from source.
-# The producer ships the PW-layout dist tree at /webkit
-# (pw_run.sh + minibrowser-{wpe,gtk}/ + peer .so); stage it at PW SDK's
-# auto-discovery path /ms-playwright/webkit-${WK_REV}/. PW's webkit driver
-# execs pw_run.sh directly — no launch shim needed (unlike Firefox).
-COPY --from=wk-source /webkit /ms-playwright/webkit-${WK_REV}
+# WebKit — musl-built WPE MiniBrowser, from source. The producer ships the
+# PW-layout dist tree at /webkit (pw_run.sh + minibrowser-{wpe,gtk}/ + peer .so);
+# stage it at PW SDK's auto-discovery path /ms-playwright/webkit-${WK_REV}/. PW's
+# webkit driver execs pw_run.sh directly — no launch shim needed (unlike Firefox).
+#
+# We COPY ONLY minibrowser-wpe (+ pw_run.sh), NOT minibrowser-gtk. pw_run.sh
+# picks the port by flag: `--headless` → minibrowser-wpe, else minibrowser-gtk.
+# PW always launches headless here, so gtk (~167 MB compressed, ~400 MB on disk)
+# is never execed — headed WebKit is unsupported on musl (libgtk-4 self-recursion
+# crash; producer Tier-2 headed is `if: false`). Dropping it is pure dead-weight
+# removal; the producer artifact still ships both for when headed lands. See
+# project_webkit_gtk_headed_recursion.
+COPY --from=wk-source /webkit/minibrowser-wpe /ms-playwright/webkit-${WK_REV}/minibrowser-wpe
+COPY --from=wk-source /webkit/pw_run.sh /ms-playwright/webkit-${WK_REV}/pw_run.sh
 RUN sudo touch /ms-playwright/webkit-${WK_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/webkit-${WK_REV}
 

--- a/playwright/alpine-browsers/chromium-headless-shell/scripts/stage-cache-layout.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/scripts/stage-cache-layout.sh
@@ -40,5 +40,20 @@ rm -rf "$OUT"
 mkdir -p "$OUT"
 cp -a "$DIST/." "$OUT/"
 
+# Strip symbol tables from the shipped ELF binaries, matching PW's official
+# prebuilt (which ships stripped). GN `symbol_level = 0` already omits DWARF
+# debug info, but the linker still emits `.symtab`/`.strtab`; strip removes them
+# with no runtime effect — the dynamic symbol table (`.dynsym`) that loading
+# needs is left untouched by `--strip-all`. `binutils` (strip) + `file` come
+# from the builder base (Dockerfile setup). Non-ELF files (.pak/.dat/.bin,
+# locales) are skipped via the `file` type check.
+before=$(du -sh "$OUT" | cut -f1)
+find "$OUT" -type f -print0 | while IFS= read -r -d '' f; do
+  case "$(file -b "$f" 2>/dev/null)" in
+    *ELF*) strip --strip-all "$f" 2>/dev/null || true ;;
+  esac
+done
+echo "Stripped ELF binaries in $OUT: ${before} -> $(du -sh "$OUT" | cut -f1)"
+
 echo "Staged cache layout at $OUT:"
 ls -lh "$OUT" | head -20


### PR DESCRIPTION
The bench (act, all-browsers) surfaced that the alpine combined image is *bigger* than ubuntu and the official PW container — counterintuitive for Alpine. Two independent reasons, two independent cuts.

## Why the image is fat

Per-layer sizes of the WebKit producer (`wk-2287`, compressed): **wpe 252 MB + gtk 167 MB**. And the from-source chromium is unstripped. Neither problem is the base.

## 1. Drop the headed WebKit (gtk) MiniBrowser — consumer-side, ~167 MB

`pw_run.sh` picks the port by flag:
```sh
MINIBROWSER_FOLDER="minibrowser-gtk";        # default (headed)
if [[ "$*" == *--headless* ]]; then
  MINIBROWSER_FOLDER="minibrowser-wpe";      # headless
fi
```
PW always launches headless here, so `minibrowser-gtk` is **never execed** — and headed WebKit is unsupported on musl anyway (libgtk-4 self-recursion, producer Tier-2 headed is `if: false`). So the combined image was shipping ~167 MB compressed / ~400 MB on disk of dead weight.

Fix: `COPY` only `minibrowser-wpe` + `pw_run.sh`, skip gtk. No producer rebuild — picks up on the next build of `Dockerfile.alpine`. Reversible; the producer artifact still ships **both** ports for when headed lands, and the conformance runner (`build-runner.sh`) still stages the full tree for its headed leg.

## 2. Strip the from-source chromium — build-side

The from-source build sets `symbol_level = 0` (no DWARF) but never `strip`s — the linker still emits `.symtab`/`.strtab`, which PW’s official prebuilt ships stripped. Added a `strip --strip-all` pass over the staged ELF binaries in `stage-cache-layout.sh` (`.dynsym` kept, so loading is unaffected; non-ELF `.pak`/`.dat` skipped via `file`).

This one only takes effect on the **next from-source rebuild + promote** — the consumer just `COPY`s the existing `chs-1223`, so I’ll dispatch that after merge.

## Open questions
- Strip is modest next to gtc. `is_official_build=true` (PGO/LTO) would shrink chromium a lot more but "significantly slower build" risks the 6h GHA cap that already forced feature cuts — deliberately **out of scope** here. Worth a separate spike?
- Should the consumer README call out that headed WebKit is intentionally absent from the shipped image (vs the producer artifact)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)