### PR TITLE
fix(chromium): overlay stage-cache-layout.sh in finalize so the strip pass reaches incremental builds

### DIFF
--- a/playwright/alpine-browsers/chromium-headless-shell/Dockerfile.finalize
+++ b/playwright/alpine-browsers/chromium-headless-shell/Dockerfile.finalize
@@ -35,6 +35,11 @@ RUN --mount=type=cache,target=/root/.cache/sccache,id=chr-sccache,sharing=locked
     --mount=type=secret,id=actions_results_url \
     bash /work/chromium-headless-shell/scripts/ninja-resume.sh /work final final
 
+# Same overlay rationale as ninja-resume.sh above: stage-cache-layout.sh is baked
+# into BASE_IMAGE at setup time, so a branch edit (e.g. the ELF strip pass) only
+# reaches this incremental finalize via a fresh COPY from the build context.
+# Harmless for a clean rebuild: the fresh script == what setup baked.
+COPY chromium-headless-shell/scripts/stage-cache-layout.sh /work/chromium-headless-shell/scripts/stage-cache-layout.sh
 RUN bash /work/chromium-headless-shell/scripts/stage-cache-layout.sh /work
 
 FROM scratch AS artifact


### PR DESCRIPTION
Follow-up to #87 (the ELF strip pass). Caught before dispatching the from-source rebuild.

## The trap

`stage-cache-layout.sh` is baked into the **setup** image (`Dockerfile.setup` COPYs the whole `scripts/` dir), and the split-build `Dockerfile.finalize` only re-COPYs `ninja-resume.sh` fresh. So the `strip --strip-all` pass I added to `stage-cache-layout.sh` in #87 would be **inert** on an incremental from-source dispatch — the finalize `RUN` reuses the setup-baked script, not the branch edit. (Same class as the `ninja-resume.sh` overlay note already in the file.)

## Fix

Overlay a fresh `COPY` of `stage-cache-layout.sh` in `Dockerfile.finalize`, mirroring the existing `ninja-resume.sh` overlay. Harmless for a clean rebuild (fresh == baked); load-bearing for the incremental path.

Only after this lands can the strip actually take effect on a dispatched rebuild → then promote `chs-fs` → `chs-1223`.