### PR TITLE
build(webkit): pin the libwpe and WPEBackend-fdo clones

### DIFF
--- a/playwright/alpine-browsers/webkit/Dockerfile.source-prep
+++ b/playwright/alpine-browsers/webkit/Dockerfile.source-prep
@@ -51,8 +51,17 @@ RUN apk add --no-cache \
 # reads NULL despite the bundled lib exposing it correctly in isolation.
 # Master may carry fixes; this overwrites apk's lib at /usr/lib so WebKit's
 # cmake configure picks up the new headers + ABI at build time.
-RUN cd /tmp && git clone --depth=1 https://github.com/WebPlatformForEmbedded/libwpe.git \
-    && cd libwpe \
+# Pinned, not `--depth=1` of master: an unpinned clone makes the build-time
+# libwpe irreproducible between builds. Pinned to a COMMIT rather than a tag on
+# purpose — libwpe's tags live on a release branch that has DIVERGED from master
+# (1.16.3 is 8 ahead / 7 behind), and 1.16.3 is precisely the apk version whose
+# musl static-init wall sent us to master in the first place. This SHA is what
+# we already build, so the pin changes nothing but reproducibility.
+RUN cd /tmp && mkdir libwpe && cd libwpe \
+    && git init -q . \
+    && git remote add origin https://github.com/WebPlatformForEmbedded/libwpe.git \
+    && git fetch -q --depth=1 origin 445a0b5579aba7eca619973ca476bb5291a85cf5 \
+    && git reset -q --hard FETCH_HEAD \
     && meson setup build --prefix=/usr --libdir=lib --buildtype=release \
         -Ddefault-backend=libWPEBackend-fdo-1.0.so.1 \
     && meson compile -C build \
@@ -65,8 +74,15 @@ RUN cd /tmp && git clone --depth=1 https://github.com/WebPlatformForEmbedded/lib
 # in WebKit's main process despite working in standalone dlopen tests.
 COPY webkit/scripts/fdo-explicit-ctor.cpp /work/fdo-explicit-ctor.cpp
 
-RUN cd /tmp && git clone --depth=1 https://github.com/Igalia/WPEBackend-fdo.git \
-    && cd WPEBackend-fdo \
+# Pinned for the same reason, and it matters more here: we replace src/fdo.cpp
+# wholesale, so an upstream move can silently desync our file from the
+# interfaces.h it includes. Newest tag 1.16.1 is again the apk version we
+# rejected.
+RUN cd /tmp && mkdir WPEBackend-fdo && cd WPEBackend-fdo \
+    && git init -q . \
+    && git remote add origin https://github.com/Igalia/WPEBackend-fdo.git \
+    && git fetch -q --depth=1 origin 84492327673fa0dedfa4fa0ab9488bed1763a5a8 \
+    && git reset -q --hard FETCH_HEAD \
     && cp /work/fdo-explicit-ctor.cpp src/fdo.cpp \
     && meson setup build --prefix=/usr --libdir=lib --buildtype=release \
     && meson compile -C build \


### PR DESCRIPTION
Both WPE clones in `Dockerfile.source-prep` were `git clone --depth=1` of master, so the libraries WebKit builds against changed silently whenever upstream moved — no two builds were guaranteed to use the same source. I hit this while chasing the WebKit conformance residuals, where "which libwpe are we actually running" turned out to be unanswerable.

Pinned to **commits, not tags**, and I want a second opinion on that call:

- libwpe's tags sit on a release branch that has **diverged** from master — `1.16.3` is 8 ahead and 7 behind — and 1.16.3 is precisely the apk version whose musl static-init wall is why we build from master at all.
- WPEBackend-fdo's newest tag `1.16.1` is likewise the apk version we rejected.

So a tag pin would swap in the code we deliberately avoided. These SHAs are what we already build, so the pin changes reproducibility and nothing else.

The fdo pin carries the larger risk independently of this PR: we replace `src/fdo.cpp` wholesale, so an upstream move can desync our file from the `interfaces.h` it includes, and that failure surfaces as a compile error hours into a build.

**Out of scope:** the strip that removes both of these from every consumer image, so the apk copies load and our `__attribute__((constructor))` fix is inert at runtime. That is a real inconsistency but a separate decision, and it is measured NOT to cause the conformance reds.

**Open question:** happy to move to tags if you would rather track releases — it would mean re-testing the musl static-init issue that sent us to master.

Note this is on a branch because every push to main under `playwright/alpine-browsers/**` starts `build-firefox`, and this change has no reason to.