### PR TITLE
fix(webkit): keep the right-click release when the input is synthetic

### DIFF
--- a/playwright/alpine-browsers/webkit/scripts/prep-source.sh
+++ b/playwright/alpine-browsers/webkit/scripts/prep-source.sh
@@ -734,6 +734,70 @@ assert_webkit_project_version() {
 }
 assert_webkit_project_version
 
+# Keep the right-click release when the input is synthetic.
+#
+# WebPageProxy::showContextMenu() discards mouse events already queued in the UI
+# process, and upstream's own comment says it fires "if we take too long to enter
+# the nested runloop". PW's locator.click() PIPELINES move/down/up — the wire
+# shows all three sent in one millisecond and acknowledged together — so on our
+# musl build the release is already queued when ShowContextMenu arrives and is
+# dropped. The page then sees ['mousedown','contextmenu'] and
+# tests/page/page-click.spec.ts:1203 fails. Sending the same three events awaited
+# one at a time passes, which is what identifies this as the discard rather than
+# a dispatch bug.
+#
+# Immediately above the discard, WebKit already exempts automation:
+#     if (RefPtr automationSession = ...processPool().automationSession()) {
+#         if (m_controlledByAutomation && automationSession->isSimulatingUserInteraction())
+#             return;
+# PW drives over the inspector rather than WebAutomationSession, so
+# automationSession() is null and it never applies. Extend the same reasoning to
+# the discard: when every event was injected by the driver there are no stray
+# user events to throw away.
+#
+# Upstream candidate — worth offering to PW rather than carrying forever.
+patch_keep_synthetic_mouse_events() {
+  local page_proxy=Source/WebKit/UIProcess/WebPageProxy.cpp
+
+  # Key the guard AND the assertion on our own marker, never on
+  # `if (!m_controlledByAutomation)` — that already occurs in
+  # activeAutomationSession(), so a generic grep makes this patch a silent
+  # no-op on the skip path and a false "applied twice" on the assert path.
+  local marker='no stray user events to discard'
+
+  if grep -q "$marker" "$page_proxy"; then
+    echo "  showContextMenu already guards the discard — drop patch_keep_synthetic_mouse_events"
+    return 0
+  fi
+
+  echo "  guard discardQueuedMouseEvents() in showContextMenu"
+  # discardQueuedMouseEvents() is called twice (didStartDrag also calls it), so
+  # arm on the comment unique to the context-menu one rather than the call.
+  awk '
+    /MouseDown event that triggered this ShowContextMenu message/ { armed = 1 }
+    armed && /^    discardQueuedMouseEvents\(\);$/ {
+      print "    // Playwright injects every event over the inspector, so there are"
+      print "    // no stray user events to discard here — and its click() pipelines"
+      print "    // press and release, so this would otherwise drop the release."
+      print "    // See prep-source.sh: patch_keep_synthetic_mouse_events."
+      print "    if (!m_controlledByAutomation)"
+      print "        discardQueuedMouseEvents();"
+      armed = 0
+      next
+    }
+    { print }
+  ' "$page_proxy" > "${page_proxy}.new"
+  mv "${page_proxy}.new" "$page_proxy"
+
+  local guards
+  guards=$(grep -c "$marker" "$page_proxy")
+  if [[ "$guards" != 1 ]]; then
+    echo "ERROR: guard applied $guards time(s) in $page_proxy, expected exactly 1" >&2
+    exit 1
+  fi
+}
+patch_keep_synthetic_mouse_events
+
 # Strip .git — ~1GB saved in the source-prep image which both port chains FROM.
 rm -rf .git
 

--- a/playwright/alpine-browsers/webkit/smoke/launch.cjs
+++ b/playwright/alpine-browsers/webkit/smoke/launch.cjs
@@ -73,6 +73,39 @@ const ok = (cond, msg) => { if (!cond) { console.error('FAIL:', msg); process.ex
   const png = await page.screenshot();
   ok(png && png.length > 100, `page.screenshot returned ${png?.length} bytes`);
 
+  // Regression: the right-click release must reach the page.
+  //
+  // Mirrors tests/page/page-click.spec.ts:1203 'should fire contextmenu event
+  // on right click in correct order' (microsoft/playwright#26515), which every
+  // non-Windows-chromium browser is expected to pass:
+  //
+  //     await expect.poll(() => entries).toEqual(['mousedown', 'contextmenu', 'mouseup'])
+  //
+  // We emitted only ['mousedown', 'contextmenu']. WebPageProxy::showContextMenu
+  // calls discardQueuedMouseEvents(), whose own comment says it drops events
+  // "if we take too long to enter the nested runloop" — and locator.click()
+  // PIPELINES move/down/up, so our release is already queued when
+  // ShowContextMenu arrives and gets discarded. Sending the same three events
+  // awaited one at a time passes, which is why this uses click(): only the
+  // pipelined shape reproduces it.
+  await page.setContent('<button id="target">Click me</button>');
+  await page.evaluate(() => {
+    const logEvent = e => console.log(e.type);
+    document.addEventListener('mousedown', logEvent);
+    document.addEventListener('mouseup', logEvent);
+    document.addEventListener('contextmenu', logEvent);
+  });
+  const mouseEvents = [];
+  page.on('console', message => mouseEvents.push(message.text()));
+  await page.getByRole('button', { name: 'Click me' }).click({ button: 'right' });
+  // A dropped event never arrives late, but poll anyway so a slow runner
+  // reports the real order rather than a truncated one.
+  for (let attempt = 0; attempt < 30 && mouseEvents.length < 3; attempt++) {
+    await page.waitForTimeout(100);
+  }
+  ok(JSON.stringify(mouseEvents) === JSON.stringify(['mousedown', 'contextmenu', 'mouseup']),
+    `right click event order (got: ${JSON.stringify(mouseEvents)})`);
+
   await browser.close();
   console.log('smoke OK');
 })().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
One of the six WebKit conformance reds, with a root cause rather than a guess.

`tests/page/page-click.spec.ts:1203` expects `['mousedown','contextmenu','mouseup']` from a right click and we emit only the first two. Three dispatch shapes, fresh context each:

| shape | ours | upstream |
| --- | --- | --- |
| `locator-click` (pipelined) | FAIL `["mousedown","contextmenu"]` | PASS |
| `awaited-manual` | PASS | PASS |
| `pipelined-manual` | FAIL | PASS |

The last two send **identical protocol frames**; the only difference is whether the release waits for the press to be acknowledged.

`WebPageProxy::showContextMenu()` calls `discardQueuedMouseEvents()`, and upstream's own comment says it drops events *"if we take too long to enter the nested runloop"*. `click()` pipelines move/down/up — the wire shows all three sent within one millisecond and acknowledged together — so our release is already queued when `ShowContextMenu` arrives. Upstream runs the same code and wins the race; a left click passes because no context menu means no discard.

Directly above the discard, WebKit already exempts automation through a `WebAutomationSession` check that PW never satisfies, because it drives over the inspector. This patch extends the same reasoning one line further down.

**Reviewer questions:**

- Is `m_controlledByAutomation` the right predicate, or should this mirror the block above and also require a session? I chose the broader one deliberately: PW has no `WebAutomationSession`, so requiring one would leave the patch inert — which is exactly the bug it fixes.
- Worth offering upstream to PW instead of carrying it? The reasoning is theirs, and they benefit on any slow machine. Happy to open it there if you agree.

**On the guard:** it keys on a marker comment, not on `if (!m_controlledByAutomation)`, which already occurs in `activeAutomationSession()`. Testing the patch against the real `WebPageProxy.cpp` instead of a fixture is what caught that — the generic grep made the skip path a silent no-op and the assert path a false "applied twice".

**Not yet built.** Validating costs a ~10h WebKit rebuild, so I have not spent it without asking. The smoke assertion is red on the current artifact (run 32474867037), which is the without-the-fix witness; the with-the-fix half needs that build.

**Out of scope:** the other two clusters. CacheStorage (record reaches disk, live read path can't see it) and camera/mic (mock stack compiled and working, centre never switched on) are still open and unrelated to this change.