### PR TITLE
build(webkit): rebuild against the patch series Playwright 1.62.1 needs

### DIFF
--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -3262,6 +3262,12 @@ jobs:
           # fixed the SIGILL, launch.cjs runs the full Tier-2 sequence
           # (launch, page, route, screenshot). If something else still
           # crashes WPEWebProcess, the core-dump step below captures bt.
+          #
+          # versions.env carries PW_WEBKIT_WPE_SOVERSION, the expected so-version
+          # of the shipped libWPEWebKit — the one version assertion that reads the
+          # built binary rather than playwright's own package.
+          set -a; . playwright/alpine-browsers/versions.env; set +a
+          : "${PW_WEBKIT_WPE_SOVERSION:?versions.env must define PW_WEBKIT_WPE_SOVERSION}"
           docker run --rm \
             --security-opt seccomp=unconfined \
             --security-opt apparmor=unconfined \
@@ -3279,6 +3285,7 @@ jobs:
             -e GALLIUM_DRIVER=llvmpipe \
             -e MESA_LOADER_DRIVER_OVERRIDE=llvmpipe \
             -e EXPECTED_WEBKIT_VERSION="${{ needs.build-webkit-finalize.outputs.webkit_version }}" \
+            -e EXPECTED_WPE_SOVERSION="$PW_WEBKIT_WPE_SOVERSION" \
             wk-candidate-runner:${{ github.sha }} \
             sh -c '
               ulimit -c unlimited 2>/dev/null || true

--- a/playwright/alpine-browsers/versions.env
+++ b/playwright/alpine-browsers/versions.env
@@ -17,6 +17,55 @@ PW_FIREFOX_SHA=c7fa3c91990bac266ee99a9e31863c202469f369
 # musl build conflicts. Verify against browser_patches/webkit/UPSTREAM_CONFIG.sh
 # in the matching PW tag.
 PW_WEBKIT_SHA=d8fa5ad85d476be6d60c96ace769a2c9293bc2a8
+# We deliberately track playwright's main branch rather than the v${PW_VERSION}
+# tag: the tag's series is authored against WebKit 343e13bf (2026-04-28) and is
+# months behind the browser PW actually ships, which is what forced us to hand-
+# backport closePage, snapshotRect's format/quality and the certificate CN
+# summary. main's pair (WebKit 4d05d732, 2026-06-11) already carries the last
+# two, so those blocks in prep-source.sh self-disable via their skip-if-present
+# guards.
+#
+# Pinned to a commit, not a branch name, so the build stays reproducible.
+# Verified before pinning: applying main's bootstrap.diff to 4d05d732 yields 0
+# failed hunks, while applying it to a July WebKit (524399615e24) yields 49 of
+# 897 — the pairing is what makes this safe, so bump BOTH by moving this ref.
+PW_WEBKIT_PATCHES_REF=c377b7f47b00d41f4639b99b66ef62a458529f46
+
+# WebKit's own version, read from Source/cmake/OptionsWPE.cmake's
+# SET_PROJECT_VERSION in the tree we actually clone. Asserted in prep-source.sh
+# so that moving PW_WEBKIT_PATCHES_REF (and with it BASE_REVISION) fails loudly
+# in the 8-minute source-prep job unless the move is declared here too.
+#
+# This exists because the smoke test's version check cannot do the job:
+# browser.version() returns a hardcoded `const BROWSER_VERSION = '26.5'` inside
+# playwright-core, compared against the same package's browsers.json — it is
+# PW checked against itself and passes whatever WebKit we built. 26.5 is a
+# Safari marketing version with no counterpart in the WebKit sources, so this
+# is the closest thing to a real engine version the tree carries.
+#   343e13bf (v1.62.1 tag's base) = 2.53.1
+#   4d05d732 (main's base)        = 2.53.3
+PW_WEBKIT_PROJECT_VERSION=2.53.3
+
+# so-version of the shipped libWPEWebKit, asserted in webkit/smoke/launch.cjs
+# against the library the build actually produced — the one version check here
+# that reads the binary rather than PW's own package.
+#
+# Derived from CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(WEBKIT c r a) in
+# Source/cmake/OptionsWPE.cmake, which libtool renders as
+# .so.<c-a>.<a>.<r>:  (11 0 10) → 1.10.0 at WebKit 343e13bf
+#                     (11 2 10) → 1.10.2 at WebKit 4d05d732
+PW_WEBKIT_WPE_SOVERSION=1.10.2
+
+# Per-browser aports refs. Each pinned to the commit whose APKBUILD pkgver
+# matches the corresponding `playwright-core@${PW_VERSION}/browsers.json`
+# pin for that browser. Find the right ref via:
+#   curl 'https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports/repository/commits?path=community/<browser>/APKBUILD&per_page=30'
+# and grab the SHA of the "upgrade to <PW's pinned version>" commit.
+#
+# Long-term: a Renovate custom manager could auto-track each against PW's
+# browsers.json, but the upstream-coordination logic isn't worth the complexity
+# for ~6 bumps/year per browser.
+
 
 # Per-browser aports refs. Each pinned to the commit whose APKBUILD pkgver
 # matches the corresponding `playwright-core@${PW_VERSION}/browsers.json`

--- a/playwright/alpine-browsers/webkit/scripts/apply-and-build-port.sh
+++ b/playwright/alpine-browsers/webkit/scripts/apply-and-build-port.sh
@@ -100,6 +100,28 @@ fi
 
 # Phase 2 — ninja MiniBrowser (progressive across resumes).
 if [[ ! -f "$BUILD_DIR/bin/MiniBrowser" ]]; then
+  # Populate the forwarding headers before anything compiles.
+  #
+  # WebKit 4d05d732 split JSC's JIT into its own subtarget
+  # (WEBKIT_DEFINE_SUBTARGET_WITH_PREFIX(JavaScriptCore JavaScriptCoreJIT ...)),
+  # and that subtarget's precompiled header does not depend on
+  # JavaScriptCore_CopyPrivateHeaders. With a cold cache and full parallelism the
+  # PCH therefore starts before the headers are symlinked and dies on
+  #   B3ValueRep.h:32:10: fatal error: 'JavaScriptCore/FPRInfo.h' file not found
+  # even though ninja generates that header seconds later (run 32232319190,
+  # 26 minutes in, unit 6601/8797). The old base had no such subtarget, which is
+  # why this only appeared when the base moved.
+  #
+  # Building the copy targets first is deterministic — unlike lowering -j or
+  # retrying, which only make the race less likely. Each is a no-op on resume
+  # rounds, and `|| true` keeps this harmless if a target is renamed upstream:
+  # the real build below still gates the round.
+  for hdr_target in WTF_CopyHeaders bmalloc_CopyHeaders JavaScriptCore_CopyPrivateHeaders; do
+    echo "--- pre-building $hdr_target ---"
+    cmake --build "$BUILD_DIR" --target "$hdr_target" || \
+      echo "note: $hdr_target not present in this WebKit revision — skipping"
+  done
+
   echo "===== Phase 2: ninja PORT=$PORT (timeout: $(remaining_seconds)s) ====="
   rc=0
   # BusyBox `timeout` syntax: -s SIG SECS PROG; no `s` suffix.

--- a/playwright/alpine-browsers/webkit/scripts/fetch-pw-patches.sh
+++ b/playwright/alpine-browsers/webkit/scripts/fetch-pw-patches.sh
@@ -17,7 +17,10 @@ PW_VERSION="${PW_VERSION:?PW_VERSION must be set}"
 
 mkdir -p "$OUT/patches" "$OUT/embedder"
 
-GH_RAW="https://raw.githubusercontent.com/microsoft/playwright/v${PW_VERSION}"
+# Patch series ref — see PW_WEBKIT_PATCHES_REF in versions.env. Defaults to the
+# release tag so the script still works standalone.
+PW_PATCHES_REF="${PW_WEBKIT_PATCHES_REF:-v${PW_VERSION}}"
+GH_RAW="https://raw.githubusercontent.com/microsoft/playwright/${PW_PATCHES_REF}"
 
 # Same retry + auth shape as firefox/scripts/fetch-pw-patches.sh — raw.gh +
 # api.gh rate-limit unauthenticated traffic to ~60/hr per IP and a fresh fetch
@@ -49,7 +52,7 @@ chmod +x "$OUT/pw_run.sh"
 fetch_tree() {
   local subdir="$1"
   local local_dir="$2"
-  retry_curl "https://api.github.com/repos/microsoft/playwright/git/trees/v${PW_VERSION}?recursive=1" \
+  retry_curl "https://api.github.com/repos/microsoft/playwright/git/trees/${PW_PATCHES_REF}?recursive=1" \
     | jq -r --arg p "browser_patches/webkit/$subdir/" '.tree[] | select(.type=="blob" and (.path|startswith($p))) | .path' \
     | while read -r path; do
         rel="${path#browser_patches/webkit/$subdir/}"
@@ -64,7 +67,7 @@ fetch_tree embedder "$OUT/embedder"
 WK_REV=$(jq -r '.browsers[] | select(.name=="webkit") | .revision' "$OUT/browsers.json")
 WK_VER=$(jq -r '.browsers[] | select(.name=="webkit") | .browserVersion' "$OUT/browsers.json")
 WK_SHA=$(awk -F= '$1=="BASE_REVISION"{gsub(/[" ]/,"",$2); print $2; exit}' "$OUT/UPSTREAM_CONFIG.sh")
-echo "PW v${PW_VERSION} pins webkit revision=${WK_REV} browserVersion=${WK_VER} (upstream SHA=${WK_SHA})"
+echo "PW v${PW_VERSION} pins webkit revision=${WK_REV} browserVersion=${WK_VER}; patches from ${PW_PATCHES_REF} (upstream SHA=${WK_SHA})"
 echo "${WK_REV}" > "$OUT/.webkit-revision"
 echo "${WK_VER}" > "$OUT/.webkit-version"
 echo "${WK_SHA}" > "$OUT/.webkit-sha"

--- a/playwright/alpine-browsers/webkit/scripts/prep-source.sh
+++ b/playwright/alpine-browsers/webkit/scripts/prep-source.sh
@@ -121,6 +121,453 @@ patch_page_override_settings() {
 }
 patch_page_override_settings
 
+# Playwright.closePage parity with the browser PW actually ships.
+#
+# playwright-core closes every WebKit page through Playwright.closePage
+# (wkPage.ts, WKPage.closePage), and Page._close() then awaits closedPromise,
+# which settles only when the browser emits Playwright.pageProxyDestroyed. Our
+# build answers -32601 "Unknown method"; sendMayFail swallows that, so the call
+# resolves, the page is never closed, the event never arrives and page.close()
+# blocks until the surrounding timeout. That is the ~2 minute
+# launchPersistentContext and the two live pageProxies where one is expected.
+#
+# The tag's patch series still closes pages the old way, through
+# PageInspectorTargetProxy::close (Target.close). PW's client moved to
+# Playwright.closePage and their webkit-2336 build has the command: the
+# protocol.json inside their zip declares 21 commands, the pinned base plus
+# bootstrap.diff yields 20, and closePage is the whole difference. Same disease
+# as patch_page_override_settings above, same fix shape — the WebPageProxy
+# methods already exist and bootstrap.diff itself calls them in four places,
+# only the inspector plumbing is missing.
+#
+# Not patched here: Cookie/SetCookieParam gained a partitionKey property in the
+# same drift. The client sends it only when set and reads it as optional, so it
+# costs nothing until a partitioned-cookie test runs; adding it needs the
+# WebKit-side cookie plumbing too. Revisit if conformance shows cookie failures.
+#
+# Drop this block once PW rolls its base past the commit that adds closePage —
+# bootstrap.diff will declare it and the early return below will say so.
+patch_playwright_close_page() {
+  local json=Source/JavaScriptCore/inspector/protocol/Playwright.json
+  local agent_h=Source/WebKit/UIProcess/InspectorPlaywrightAgent.h
+  local agent=Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
+
+  if grep -q '"closePage"' "$json"; then
+    echo "  Playwright.json already carries closePage — PW rolled its base, drop patch_playwright_close_page"
+    return 0
+  fi
+
+  echo "  add Playwright.closePage (protocol + agent)"
+  awk '
+    /"name": "setPageZoomFactor",/ { seen = 1 }
+    seen && !done && /^        },$/ {
+      print
+      print "        {"
+      print "            \"name\": \"closePage\","
+      print "            \"description\": \"Closes the page, destroying the page proxy. Works for both live and crashed pages.\","
+      print "            \"parameters\": ["
+      print "                { \"name\": \"pageProxyId\", \"$ref\": \"PageProxyID\", \"description\": \"Unique identifier of the page proxy.\" },"
+      print "                { \"name\": \"runBeforeUnload\", \"type\": \"boolean\", \"optional\": true, \"description\": \"Whether to run the beforeunload page handlers.\" }"
+      print "            ]"
+      print "        },"
+      done = 1
+      next
+    }
+    { print }
+  ' "$json" > "$json.new" && mv "$json.new" "$json"
+
+  awk '
+    !done && /setPageZoomFactor\(const String& pageProxyID/ {
+      print
+      print "    Inspector::Protocol::ErrorStringOr<void> closePage(const String& pageProxyID, std::optional<bool>&& runBeforeUnload) override;"
+      done = 1
+      next
+    }
+    { print }
+  ' "$agent_h" > "$agent_h.new" && mv "$agent_h.new" "$agent_h"
+
+  awk '
+    /ErrorStringOr<void> InspectorPlaywrightAgent::setPageZoomFactor/ { seen = 1 }
+    seen && !done && /^}$/ {
+      print
+      print ""
+      print "Inspector::Protocol::ErrorStringOr<void> InspectorPlaywrightAgent::closePage(const String& pageProxyID, std::optional<bool>&& runBeforeUnload)"
+      print "{"
+      print "    auto* pageProxyChannel = m_pageProxyChannels.get(pageProxyID);"
+      print "    if (!pageProxyChannel)"
+      print "        return makeUnexpected(\"Unknown pageProxyID\"_s);"
+      print ""
+      print "    // Mirrors PageInspectorTargetProxy::close: tryClose() runs the"
+      print "    // beforeunload handlers, closePage() skips them."
+      print "    if (runBeforeUnload.value_or(false))"
+      print "        pageProxyChannel->page().tryClose();"
+      print "    else"
+      print "        pageProxyChannel->page().closePage();"
+      print "    return { };"
+      print "}"
+      done = 1
+      next
+    }
+    { print }
+  ' "$agent" > "$agent.new" && mv "$agent.new" "$agent"
+
+  local in_json in_h in_cpp
+  in_json=$(grep -c '"closePage"' "$json")
+  in_h=$(grep -c 'closePage(const String& pageProxyID' "$agent_h")
+  in_cpp=$(grep -c 'InspectorPlaywrightAgent::closePage' "$agent")
+  if [[ "$in_json" != 1 ]] || [[ "$in_h" != 1 ]] || [[ "$in_cpp" != 1 ]]; then
+    echo "ERROR: closePage appears $in_json/$in_h/$in_cpp time(s) in json/h/cpp, expected 1 each" >&2
+    exit 1
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$json" \
+      || { echo "ERROR: $json is not valid JSON after patch" >&2; exit 1; }
+  fi
+}
+patch_playwright_close_page
+
+# Page.snapshotRect image format parity with the browser PW actually ships.
+#
+# playwright-core asks for the screenshot format over the wire —
+# `Page.snapshotRect({ format: 'jpeg' | 'webp' | 'png', quality })` — and on
+# Linux it does NOT re-encode client-side (wkPage.ts recodes only on darwin).
+# It then strips the `data:image/<fmt>;base64,` prefix WITHOUT checking the
+# mime, so whatever we encode is handed to the caller as if it were the
+# requested format.
+#
+# The tag's patch series adds only `omitDeviceScaleFactor` to snapshotRect and
+# still hardcodes `encodeDataURL(..., "image/png")`, so every screenshot comes
+# back PNG. Symptoms, all one root cause: `Error: WebP decode failed`,
+# `Error: SOI not found` for jpeg, and "quality option" tests failing because
+# PNG ignores quality. PNG-format tests pass, which is why this looked like a
+# webp-specific problem for a long time (it is not — see
+# project_wk_webp_dead_hypotheses).
+#
+# Same drift as patch_playwright_close_page: PW's shipped webkit-2336
+# protocol.json declares snapshotRect with `format` + `quality` and a
+# Page.ImageFormat enum; the pinned base plus bootstrap.diff declares neither.
+# A full domain-by-domain diff of their protocol.json against ours found
+# exactly these two gaps plus the closePage one, nothing else.
+#
+# Semantics come from their protocol.json's own description: quality is ignored
+# for png, defaults to 80 for jpeg, and for webp an omitted quality or 100
+# means lossless. The Skia encoders are all compiled in already
+# (SkJpegEncoder/SkWebpEncoder/SkPngEncoder in ImageUtilitiesSkia.cpp) and take
+# quality as a 0..1 double — but at the pinned base the webp path never sets
+# fCompression, so "lossless by default" needs the upstream webpEncoderOptions
+# helper backported too (WebKit main added it after our base).
+patch_page_snapshot_format() {
+  local json=Source/JavaScriptCore/inspector/protocol/Page.json
+  local agent_h=Source/WebCore/inspector/agents/InspectorPageAgent.h
+  local agent=Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+  local skia=Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
+
+  for f in "$json" "$agent_h" "$agent" "$skia"; do
+    [[ -f "$f" ]] || { echo "ERROR: expected $f to exist" >&2; exit 1; }
+  done
+
+  if grep -q '"ImageFormat"' "$json"; then
+    echo "  Page.json already carries ImageFormat — PW rolled its base, drop patch_page_snapshot_format"
+    return 0
+  fi
+
+  echo "  add Page.ImageFormat + snapshotRect format/quality (protocol + agent + skia)"
+
+  awk '
+    !done_type && /^    "types": \[$/ {
+      print
+      print "        {"
+      print "            \"id\": \"ImageFormat\","
+      print "            \"type\": \"string\","
+      print "            \"enum\": [\"png\", \"jpeg\", \"webp\"],"
+      print "            \"description\": \"Image format used to encode a captured snapshot.\""
+      print "        },"
+      done_type = 1
+      next
+    }
+    !done_param && /"name": "omitDeviceScaleFactor"/ {
+      sub(/\}$/, "},")
+      print
+      print "                { \"name\": \"format\", \"$ref\": \"ImageFormat\", \"optional\": true, \"description\": \"Image format of the resulting snapshot. Defaults to \\\"png\\\".\" },"
+      print "                { \"name\": \"quality\", \"type\": \"integer\", \"optional\": true, \"description\": \"Compression quality from 0 to 100 (ignored for the \\\"png\\\" format). For \\\"jpeg\\\" it defaults to 80. For \\\"webp\\\", omitting the quality or setting it to 100 produces a lossless image; any other value uses lossy compression at that quality.\" }"
+      done_param = 1
+      next
+    }
+    { print }
+  ' "$json" > "$json.new" && mv "$json.new" "$json"
+
+  awk '
+    !done && /ErrorStringOr<String> snapshotRect\(int x, int y, int width, int height, Inspector::Protocol::Page::CoordinateSystem, std::optional<bool>&& omitDeviceScaleFactor\);/ {
+      sub(/std::optional<bool>&& omitDeviceScaleFactor\);/, "std::optional<bool>\\&\\& omitDeviceScaleFactor, std::optional<Inspector::Protocol::Page::ImageFormat>\\&\\& format, std::optional<int>\\&\\& quality);")
+      done = 1
+    }
+    { print }
+  ' "$agent_h" > "$agent_h.new" && mv "$agent_h.new" "$agent_h"
+
+  # Two encodeDataURL(..., "image/png") call sites exist (snapshotNode and
+  # snapshotRect); only the latter takes a format, so gate on having seen the
+  # snapshotRect definition first.
+  awk '
+    /ErrorStringOr<String> InspectorPageAgent::snapshotRect\(/ {
+      sub(/std::optional<bool>&& omitDeviceScaleFactor\)/, "std::optional<bool>\\&\\& omitDeviceScaleFactor, std::optional<Inspector::Protocol::Page::ImageFormat>\\&\\& format, std::optional<int>\\&\\& quality)")
+      in_rect = 1
+      print
+      next
+    }
+    in_rect && !done && /return encodeDataURL\(WTF::move\(snapshot\), "image\/png"_s\);/ {
+      print "    String mimeType = \"image/png\"_s;"
+      print "    std::optional<int> defaultQuality;"
+      print "    if (format) {"
+      print "        switch (*format) {"
+      print "        case Inspector::Protocol::Page::ImageFormat::Png:"
+      print "            break;"
+      print "        case Inspector::Protocol::Page::ImageFormat::Jpeg:"
+      print "            mimeType = \"image/jpeg\"_s;"
+      print "            defaultQuality = 80;"
+      print "            break;"
+      print "        case Inspector::Protocol::Page::ImageFormat::Webp:"
+      print "            mimeType = \"image/webp\"_s;"
+      print "            // An omitted quality (or 100) means lossless, which"
+      print "            // patch_webp_lossless_encoding makes the encoder honour."
+      print "            defaultQuality = 100;"
+      print "            break;"
+      print "        }"
+      print "    }"
+      print ""
+      print "    std::optional<double> encodeQuality;"
+      print "    if (defaultQuality) {"
+      print "        int value = quality.value_or(*defaultQuality);"
+      print "        if (value < 0)"
+      print "            value = 0;"
+      print "        else if (value > 100)"
+      print "            value = 100;"
+      print "        encodeQuality = value / 100.0;"
+      print "    }"
+      print ""
+      print "    return encodeDataURL(WTF::move(snapshot), mimeType, encodeQuality);"
+      done = 1
+      next
+    }
+    { print }
+  ' "$agent" > "$agent.new" && mv "$agent.new" "$agent"
+
+  # Backport upstream's webpEncoderOptions: at the pinned base neither webp
+  # path sets fCompression, so quality 100 is lossy and PW's "webp screenshots
+  # should be lossless by default" fails. Replaces the two-line quality block
+  # that follows each `SkWebpEncoder::Options options;`.
+  awk '
+    /^static sk_sp<SkData> encodeAcceleratedImage\(/ && !done_fn {
+      print "static SkWebpEncoder::Options webpEncoderOptions(std::optional<double> quality)"
+      print "{"
+      print "    SkWebpEncoder::Options options;"
+      print "    if (quality && *quality == 1.0) {"
+      print "        // A quality of 1.0 selects lossless compression. For lossless encoding"
+      print "        // fQuality is the compression effort rather than the visual quality."
+      print "        options.fCompression = SkWebpEncoder::Compression::kLossless;"
+      print "        options.fQuality = 75;"
+      print "    } else if (quality && *quality >= 0.0 && *quality < 1.0)"
+      print "        options.fQuality = static_cast<int>(*quality * 100.0 + 0.5);"
+      print "    return options;"
+      print "}"
+      print ""
+      done_fn = 1
+    }
+    /SkWebpEncoder::Options options;$/ {
+      sub(/SkWebpEncoder::Options options;/, "SkWebpEncoder::Options options = webpEncoderOptions(quality);")
+      print
+      skip = 2
+      next
+    }
+    skip > 0 { skip--; next }
+    { print }
+  ' "$skia" > "$skia.new" && mv "$skia.new" "$skia"
+
+  local n_type n_param n_h n_cpp n_skia_fn n_skia_use
+  n_type=$(grep -c '"id": "ImageFormat"' "$json")
+  n_param=$(grep -c '"name": "format", "\$ref": "ImageFormat"' "$json")
+  n_h=$(grep -c 'ImageFormat>&& format' "$agent_h")
+  n_cpp=$(grep -c 'ImageFormat::Webp:' "$agent")
+  n_skia_fn=$(grep -c '^static SkWebpEncoder::Options webpEncoderOptions' "$skia")
+  n_skia_use=$(grep -c 'webpEncoderOptions(quality);' "$skia")
+  if [[ "$n_type" != 1 ]] || [[ "$n_param" != 1 ]] || [[ "$n_h" != 1 ]] \
+     || [[ "$n_cpp" != 1 ]] || [[ "$n_skia_fn" != 1 ]] || [[ "$n_skia_use" != 2 ]]; then
+    echo "ERROR: snapshot-format patch counts type=$n_type param=$n_param h=$n_h cpp=$n_cpp skia_fn=$n_skia_fn skia_use=$n_skia_use (want 1/1/1/1/1/2)" >&2
+    exit 1
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$json" \
+      || { echo "ERROR: $json is not valid JSON after patch" >&2; exit 1; }
+  fi
+}
+patch_page_snapshot_format
+
+# Skia's WebP encoder defaults to lossy compression and never sets fCompression
+# at the pinned base, so the quality patch_page_snapshot_format sends is applied
+# as a LOSSY quality — a webp screenshot decodes at the right dimensions but its
+# pixels differ from the png. Two upstream tests pin the contract that quality
+# 100 (or omitted) is lossless and quality 80 is not:
+#   page-screenshot.spec.ts:307 webp screenshots should be lossless by default
+#   elementhandle-screenshot.spec.ts:38 should work with webp
+# Both failed on run 32263015377 for this reason alone.
+patch_webp_lossless_encoding() {
+  local img=Source/WebCore/platform/graphics/skia/ImageUtilitiesSkia.cpp
+
+  [[ -f "$img" ]] || { echo "ERROR: expected $img to exist" >&2; exit 1; }
+
+  if grep -q 'kLossless' "$img"; then
+    echo "  WebP encoder already selects lossless — PW rolled its base, drop patch_webp_lossless_encoding"
+    return 0
+  fi
+
+  echo "  make the WebP encoder lossless at quality 100"
+  awk '
+    /SkWebpEncoder::Options options;/ { print; in_webp = 1; next }
+    in_webp && /options\.fQuality = static_cast<int>\(\*quality \* 100\.0 \+ 0\.5\);/ {
+      print
+      print "        // Skia defaults WebP to lossy and reads fQuality as the lossy quality;"
+      print "        // kLossless repurposes it as the compression effort. The PW"
+      print "        // contract: an omitted quality (or 100) is lossless."
+      print "        if (options.fQuality == 100)"
+      print "            options.fCompression = SkWebpEncoder::Compression::kLossless;"
+      in_webp = 0
+      next
+    }
+    { print }
+  ' "$img" > "$img.new" && mv "$img.new" "$img"
+
+  # Two encode paths (accelerated + unaccelerated); the jpeg branches share the
+  # fQuality line, so a count of 2 also proves they were left alone.
+  local n
+  n=$(grep -c 'options.fCompression = SkWebpEncoder::Compression::kLossless;' "$img")
+  if [[ "$n" != 2 ]]; then
+    echo "ERROR: webp lossless patch applied $n times, expected 2" >&2
+    exit 1
+  fi
+}
+patch_webp_lossless_encoding
+
+# Playwright.setLanguages must go through WebProcessPool, not just its config.
+#
+# The tag's patch sets the languages on the process pool's *configuration*
+# object, which is only read when a process launches. So a web process started
+# afterwards picks the locale up (navigator.languages is correct) while every
+# already-running process keeps the old value — and on the soup ports the
+# Accept-Language header is built in the network process, which is long since
+# running. That is exactly the split we see: the navigator.language tests pass
+# and all three Accept-Language ones fail (header, user header, and the
+# WebSocket handshake).
+#
+# WebProcessPool::setOverrideLanguages is the API that actually propagates: it
+# sets the global override and notifies the live web processes, the GPU process
+# and, under `#if USE(SOUP)`, every NetworkProcessProxy. Keep the configuration
+# assignment too so processes launched later still inherit it.
+#
+# Unlike the other blocks here this is not a protocol gap — a full domain diff
+# (commands, events, types AND enum members) against PW's shipped
+# protocol.json shows Playwright.setLanguages already matching. The command
+# arrives and is accepted; only its effect was incomplete.
+patch_playwright_set_languages() {
+  local agent=Source/WebKit/UIProcess/InspectorPlaywrightAgent.cpp
+
+  [[ -f "$agent" ]] || { echo "ERROR: expected $agent to exist" >&2; exit 1; }
+
+  if grep -q 'processPool->setOverrideLanguages' "$agent"; then
+    echo "  setLanguages already goes through WebProcessPool — PW rolled its base, drop patch_playwright_set_languages"
+    return 0
+  fi
+
+  echo "  route Playwright.setLanguages through WebProcessPool"
+  awk '
+    !done && /browserContext->processPool->configuration\(\)\.setOverrideLanguages\(WTF::move\(items\)\);/ {
+      print "    browserContext->processPool->configuration().setOverrideLanguages(Vector<String>(items));"
+      print "    // The configuration is only consulted when a process launches, so this"
+      print "    // second call is what reaches the processes already running — including"
+      print "    // the network process, where the soup ports build Accept-Language."
+      print "    browserContext->processPool->setOverrideLanguages(WTF::move(items));"
+      done = 1
+      next
+    }
+    { print }
+  ' "$agent" > "$agent.new" && mv "$agent.new" "$agent"
+
+  local n_pool n_conf
+  n_pool=$(grep -c 'processPool->setOverrideLanguages(WTF::move(items));' "$agent")
+  n_conf=$(grep -c 'configuration().setOverrideLanguages(Vector<String>(items));' "$agent")
+  if [[ "$n_pool" != 1 ]] || [[ "$n_conf" != 1 ]]; then
+    echo "ERROR: setLanguages patch counts pool=$n_pool conf=$n_conf, expected 1 each" >&2
+    exit 1
+  fi
+}
+patch_playwright_set_languages
+
+# Certificate subject should be the CN, not the whole distinguished name.
+#
+# GLib's GTlsCertificate exposes `subject-name` as a full RFC 2253 DN
+# ("CN=playwright-test"), and at the pinned base CertificateInfo::summary()
+# assigns it straight through. PW reads that value as-is
+# (wkPage.ts: response.security.certificate.subject) and its HAR tests expect
+# the bare common name, so both security-details tests fail on one string:
+#
+#     - "subjectName": "playwright-test"
+#     + "subjectName": "CN=playwright-test"
+#
+# Upstream fixed this after our base by extracting a summary from the DN —
+# prefer CN, then O, else the DN — to match SecCertificateCopySubjectSummary on
+# macOS. Backport that helper verbatim. Its includes are already present: the
+# include block of this file is byte-identical between the pinned base and
+# upstream main, so split/trim/isASCIIWhitespace/notFound all resolve.
+patch_certificate_subject_summary() {
+  local cert=Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
+
+  [[ -f "$cert" ]] || { echo "ERROR: expected $cert to exist" >&2; exit 1; }
+
+  if grep -q 'subjectSummaryFromDN' "$cert"; then
+    echo "  CertificateInfoSoup already summarises the DN — PW rolled its base, drop patch_certificate_subject_summary"
+    return 0
+  fi
+
+  echo "  extract the CN from the certificate subject DN"
+  awk '
+    !done_fn && /^std::optional<CertificateSummary> CertificateInfo::summary\(\) const$/ {
+      print "// GLib'"'"'s GTlsCertificate::subject-name property returns a full RFC 2253 distinguished name"
+      print "// (e.g. \"CN=example.com,O=Org,C=US\"). Extract a human-readable summary by preferring the"
+      print "// CN attribute, then O, to match the behaviour of SecCertificateCopySubjectSummary on macOS."
+      print "static String subjectSummaryFromDN(const String& dn)"
+      print "{"
+      print "    String organization;"
+      print "    for (auto& component : dn.split('"'"','"'"')) {"
+      print "        auto equalsPos = component.find('"'"'='"'"');"
+      print "        if (equalsPos == notFound)"
+      print "            continue;"
+      print "        auto type = component.left(equalsPos).trim(isASCIIWhitespace<char16_t>);"
+      print "        auto value = component.substring(equalsPos + 1).trim(isASCIIWhitespace<char16_t>);"
+      print "        if (type == \"CN\"_s)"
+      print "            return value;"
+      print "        if (type == \"O\"_s && organization.isEmpty())"
+      print "            organization = value;"
+      print "    }"
+      print "    return organization.isEmpty() ? dn : organization;"
+      print "}"
+      print ""
+      done_fn = 1
+    }
+    !done_use && /summaryInfo\.subject = String::fromUTF8\(subjectName\.get\(\)\);/ {
+      sub(/String::fromUTF8\(subjectName\.get\(\)\);/, "subjectSummaryFromDN(String::fromUTF8(subjectName.get()));")
+      done_use = 1
+    }
+    { print }
+  ' "$cert" > "$cert.new" && mv "$cert.new" "$cert"
+
+  local n_fn n_use
+  n_fn=$(grep -c '^static String subjectSummaryFromDN' "$cert")
+  n_use=$(grep -c 'summaryInfo.subject = subjectSummaryFromDN(' "$cert")
+  if [[ "$n_fn" != 1 ]] || [[ "$n_use" != 1 ]]; then
+    echo "ERROR: subject-summary patch counts fn=$n_fn use=$n_use, expected 1 each" >&2
+    exit 1
+  fi
+}
+patch_certificate_subject_summary
+
 # PW's bootstrap.diff flips ENABLE_ORIENTATION_EVENTS 0→1 in PlatformEnable.h,
 # but ENABLE_ORIENTATION_EVENTS is a WEBKIT_OPTION_DEFINE'd cmake option, so
 # the generated cmakeconfig.h emits `#define ENABLE_ORIENTATION_EVENTS 0`
@@ -253,6 +700,39 @@ if [[ -f "$SOUP_FILE" ]] && ! grep -q 'download destination parent' "$SOUP_FILE"
     exit 1
   fi
 fi
+
+# Assert the engine version of the tree we just cloned + patched.
+#
+# The smoke test cannot do this: browser.version() is a hardcoded constant in
+# playwright-core compared against the same package's browsers.json, so it
+# passes for any WebKit we build. SET_PROJECT_VERSION is the closest thing to a
+# real engine version the sources carry, and it moves with the base
+# (343e13bf = 2.53.1, 4d05d732 = 2.53.3). Checking it here means a base move
+# that nobody declared fails in this 8-minute job instead of shipping a
+# mislabelled artifact hours later.
+assert_webkit_project_version() {
+  local cmake_file=Source/cmake/OptionsWPE.cmake
+  local actual
+  actual=$(awk -F'[()]' '/^ *SET_PROJECT_VERSION\(/ {
+             split($2, v, " "); print v[1] "." v[2] "." v[3]; exit }' "$cmake_file")
+  if [[ -z "$actual" ]]; then
+    echo "ERROR: could not read SET_PROJECT_VERSION from $cmake_file" >&2
+    exit 1
+  fi
+  echo "  WebKit project version: $actual"
+  if [[ -z "${PW_WEBKIT_PROJECT_VERSION:-}" ]]; then
+    echo "ERROR: PW_WEBKIT_PROJECT_VERSION is unset — an unset expectation would make this vacuous" >&2
+    exit 1
+  fi
+  if [[ "$actual" != "$PW_WEBKIT_PROJECT_VERSION" ]]; then
+    echo "ERROR: WebKit project version is $actual but versions.env declares $PW_WEBKIT_PROJECT_VERSION." >&2
+    echo "       The base moved (PW_WEBKIT_PATCHES_REF → UPSTREAM_CONFIG BASE_REVISION)." >&2
+    echo "       Update PW_WEBKIT_PROJECT_VERSION if that move is intended." >&2
+    exit 1
+  fi
+  echo "$actual" > "$WORK/.webkit-project-version"
+}
+assert_webkit_project_version
 
 # Strip .git — ~1GB saved in the source-prep image which both port chains FROM.
 rm -rf .git

--- a/playwright/alpine-browsers/webkit/smoke/launch.cjs
+++ b/playwright/alpine-browsers/webkit/smoke/launch.cjs
@@ -7,6 +7,9 @@
 //
 // CommonJS so NODE_PATH=/usr/local/lib/node_modules works (ESM ignores it).
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const { webkit } = require('playwright');
 
 const ok = (cond, msg) => { if (!cond) { console.error('FAIL:', msg); process.exit(1); } else { console.log('OK  :', msg); } };
@@ -19,17 +22,38 @@ const ok = (cond, msg) => { if (!cond) { console.error('FAIL:', msg); process.ex
   const browser = await webkit.launch();
   ok(browser, 'webkit.launch() returned a browser');
 
-  // WebKit has no Tier-1 `--version` leg — MiniBrowser-wpe reports none — so
-  // this is the only place the artifact's version gets checked at all, and
-  // promote-webkit needs this job, so it gates the `wk-<version>` tag. Without
-  // it that tag is derived purely from PW's pin and will happily label a stale
-  // binary, which is precisely how `ff-150.0.2` ended up on a Firefox 147.0.1.
-  // Required rather than skip-if-unset: an unset env would make the assertion
-  // vacuous and nothing would say so.
+  // browser.version() does NOT read the browser. playwright-core carries
+  // `const BROWSER_VERSION = '26.5'` in webkit/wkBrowser.ts and returns it
+  // verbatim, and EXPECTED_WEBKIT_VERSION comes from the same package's
+  // browsers.json — so this compares PW against itself and passes whatever
+  // WebKit we built. Kept because a mismatch still means the installed client
+  // disagrees with its own pin, but it can NOT catch a mislabelled artifact.
   const expected = process.env.EXPECTED_WEBKIT_VERSION;
   ok(expected, 'EXPECTED_WEBKIT_VERSION is set');
   const actual = browser.version();
-  ok(actual === expected, `browser.version() = ${actual}, expected ${expected}`);
+  ok(actual === expected, `browser.version() = ${actual} (playwright-core constant), expected ${expected}`);
+
+  // The real check: read the engine version off the shipped library. WebKit's
+  // libtool triple in Source/cmake/OptionsWPE.cmake produces
+  // libWPEWebKit-<api>.so.<current-age>.<age>.<revision>, and it moves with the
+  // base — (11 0 10) → 1.10.0 at WebKit 343e13bf, (11 2 10) → 1.10.2 at
+  // 4d05d732. So this is a value only the built binary can supply, checked
+  // against a checked-in expectation.
+  const expectedSo = process.env.EXPECTED_WPE_SOVERSION;
+  ok(expectedSo, 'EXPECTED_WPE_SOVERSION is set');
+  const distDir = path.dirname(webkit.executablePath());
+  // PW nests each port's libraries under minibrowser-{wpe,gtk}/lib, so the
+  // library never sits beside the launcher executablePath() points at.
+  const soRe = /^libWPEWebKit-[\d.]+\.so\.(\d+\.\d+\.\d+)$/;
+  const entries = fs.readdirSync(distDir, { recursive: true });
+  const found = entries.map(n => path.basename(n).match(soRe)).filter(Boolean);
+  ok(found.length > 0,
+    `found a versioned libWPEWebKit under ${distDir} (saw: ${
+      entries.filter(n => path.basename(n).startsWith('libWPEWebKit'))
+        .join(', ') || 'none'})`);
+  const soVersion = found[0][1];
+  ok(soVersion === expectedSo,
+    `libWPEWebKit so-version = ${soVersion}, expected ${expectedSo}`);
 
   const ctx = await browser.newContext();
   ok(ctx, 'browser.newContext()');


### PR DESCRIPTION
Playwright 1.62.1 sends `Page.overrideSetting: PushAPIEnabled` on every `newPage`, and no WebKit we had published understood it — both `wk-2336` (Aug 13) and `wk-edge` came from the patch series paired with the April base. #99 landed chromium and firefox on 1.62.1 and had to skip the two `[webkit]` tests on alpine to do it (#100). This is the half that makes the skip unnecessary.

Brings the four webkit scripts and three pins over from `perf/chromium-pgo-1.62`, which is where the 1.62.1 WebKit toolchain already lived. The pins carry their rationale verbatim rather than a summary, because the patch series and the base are a matched pair — verified as 0 failed hunks against `4d05d732` versus 49 of 897 against a July tree — so they only ever move together.

**Verified against the artifact, not inferred from a green build.** The build from this branch published `wk-sha-6cc68470`, and Playwright 1.62.1 `newPage` succeeds against it. That is the whole claim, and it is the one thing CI here does **not** demonstrate: the webkit build job is dispatch-gated and off by default, so this PR's checks will not rebuild WebKit. Treat a green tick on this PR as "nothing else broke", not as proof the fix works.

The second commit exists because I half-ported the first time: the scripts came over but not the workflow env that feeds them, so the smoke died on `FAIL: EXPECTED_WPE_SOVERSION is set` after a clean 4-hour build. That is the one version assertion that reads the **built binary** — libWPEWebKit's so-name — rather than playwright-core's hardcoded constant, which the same smoke now labels honestly in its own output (`browser.version() = 26.5 (playwright-core constant)`). Losing it is exactly the gap that let a WebKit which cannot serve 1.62.1 pass every version check we had, `OK : webkit 26.5` included.

**Sequencing — this PR alone does not close #100.** `promote-webkit` requires `conformance-webkit` as well as the smoke, so after merge the order is: dispatch `build_webkit=true` on main → conformance → promote republishes `wk-2336` from the new series → *then* the alpine skip and the perf-probe skip come out in a follow-up. Removing them here would point the tests at the current `wk-2336`, which is still the August image, and they would fail.

**Out of scope, considered and not done:** the three patches on `fix/webkit-residual-patches` (synthetic mouse events, mock capture, ALPINE-DIAG). The two branches' `prep-source.sh` have genuinely divergent patch sets — 5 patches here, 3 there, 2 shared — and those three were authored against the old series, where two of the five here self-disable on the new base via skip-if-present guards. Whether they still apply is unknown. Landing a WebKit that serves 1.62.1 first, then re-porting them against a known-good base.

**Question:** the contextmenu fix on that branch is validated (`right click event order` came back `["mousedown","contextmenu","mouseup"]` on a real build) — do you want me to re-port it on top of this once merged, or fold it into the same follow-up as the skip removals?

Refs #100.
