### PR TITLE
perf(firefox): build libpng and zlib from Mozilla's tree — ~25% faster PNG screenshots

### DIFF
--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -429,6 +429,53 @@ else
   cat "$APORTS/mozconfig" "$OVERLAY" > .mozconfig
 fi
 
+# 7b. Build libpng and zlib from Mozilla's tree instead of Alpine's.
+#
+# aports asks for the system copies; the PNG our screenshots produce is then
+# 40150 B against Playwright's official build's 26801 B for a bitmap proven
+# identical — the canvas control's JPEG is byte-for-byte the same on both
+# sides, same sha, so only the encoder can differ.
+#
+# Measured ours-vs-ours on one runner (32640911593, 32641010090): PNG
+# screenshots 0.70-0.78x, i.e. ~25% faster, with png_viewport falling
+# 25018 -> 12188 B on the real page. The JPEG rows stay at 0.97-1.21x around
+# unity across both runs, which is the control: same page, same capture, same
+# transport, identical bytes and sha. Every row is flagged n.s. individually
+# because the single-row noise floor is ~±20%, but PNG never approached 1.0 in
+# four measurements while JPEG never approached 0.75 in six.
+#
+# BOTH or neither. Removing one alone changes nothing at all — verified by
+# DT_NEEDED on all four arms, and both single arms did drop their library.
+# With --with-system-png kept, PNG encoding happens inside libpng16.so.16,
+# which carries its OWN linkage to system libz, so an in-tree zlib is compiled
+# into libxul and never sits on the PNG path. And Mozilla's libpng against
+# system zlib is byte-identical to Alpine's. Only with both in-tree does the
+# path reach Mozilla's deflate.
+#
+# Costs +122,670 B of image. --with-system-jpeg deliberately stays: the JPEG
+# control already matches the reference byte-for-byte, so it is not part of
+# this.
+#
+# Deleted rather than overridden with --without-system-*: moz.configure
+# rejects a --with and a --without of the same option in one mozconfig.
+# A no-op here is acceptable rather than fatal: if aports ever stops asking
+# for the system copies we are already where we want to be. It is still worth
+# saying out loud, because the removal below would then be dead code.
+if ! grep -qE -- '^ac_add_options --with-system-(png|zlib)$' .mozconfig; then
+  echo "::warning::aports no longer sets --with-system-png/zlib — removal is a no-op"
+fi
+sed -i \
+  -e '/^ac_add_options --with-system-png$/d' \
+  -e '/^ac_add_options --with-system-zlib$/d' \
+  .mozconfig
+# `if`, not `grep && { exit 1; }`: under `set -e` the && form aborts on the
+# GOOD path, where grep correctly finds nothing and returns 1.
+if grep -qE -- '^ac_add_options --with-system-(png|zlib)$' .mozconfig; then
+  echo "ERROR: a --with-system-png/zlib line survived the removal" >&2
+  exit 1
+fi
+echo "  imaging: libpng + zlib built from Mozilla's tree (system copies removed)"
+
 # 7a. DIAGNOSTIC: PW_ENABLE_TESTS — include xpcshell + gtest + mochitest
 #     harness so the validation workflow can run Mozilla's own self-tests.
 if [[ "$PW_ENABLE_TESTS" == "1" ]]; then


### PR DESCRIPTION
Our PNG screenshots came out 40150 B against Playwright's official build's 26801 B for a bitmap proven identical — the canvas control's JPEG is byte-for-byte the same on both sides, same sha — so only the encoder could account for it.

You said the criterion is test speed rather than artifact size, and that reframing is what this PR is built on. Everything I had measured until then was bytes, because bytes are deterministic and settle an attribution argument; the timing question needed its own experiment, **ours against ours on one runner** rather than ours-against-official, which confounds musl, the runner and the build.

Two runs, [32640911593](https://github.com/jclaveau/ci-prebuilds/actions/runs/32640911593) and [32641010090](https://github.com/jclaveau/ci-prebuilds/actions/runs/32641010090):

| row | run 1 | run 2 |
|---|---|---|
| `png_viewport` | 0.77x | 0.70x |
| `png_canvas_control` | 0.78x | 0.75x |
| `jpeg_q80_viewport` | 0.97x | 1.21x |
| `jpeg_q80_clip_16x16` | 1.00x | 0.99x |
| `jpeg_q80_canvas_control` | 1.02x | 1.09x |

**~25% off every PNG screenshot**, and `png_viewport` bytes fall 25018 → 12188 on the real page — the smaller artifact comes *with* the speed rather than traded against it.

Read it as two populations, not per-row significance. Every row is flagged `n.s.` because the single-row noise floor is ~±20% — run 2's JPEG hit 1.21x on a row whose bytes and sha are *identical* between the two images, which is what that noise looks like. But PNG never approached 1.0 in four measurements while JPEG never approached 0.75 in six, and the JPEG rows are a real control: same page, same capture, same transport.

**Both libraries or neither**, and that took three wrong conclusions to establish. The zlib-only and libpng-only arms each came back at 40150 B, bit-identical to the baseline. I twice wrote that down as "libpng carries it by elimination", which assumed an independence the data never supported. `DT_NEEDED` on all four artifacts is what settled it — both single arms *did* drop their library, so the arms were valid and the interaction is real: with `--with-system-png` kept, PNG encoding happens inside `libpng16.so.16`, which carries its **own** linkage to system libz, so an in-tree zlib is compiled into libxul and never sits on the PNG path. And Mozilla's libpng against system zlib is byte-identical to Alpine's. Only with both in-tree does the path reach Mozilla's deflate (their tree carries `zlib-rs`).

**Cost:** +122,670 B of image, permanently, for every consumer.

**Retrocompat:** none — same binary surface, same versions, only the PNG bytes change (and they become byte-identical to what official produces).

**Out of scope, considered and not done:**
- `--with-system-jpeg` stays. The JPEG control already matches the reference byte-for-byte, so it was never part of this question.
- Chromium and WebKit are unaffected — both already match official byte-for-byte on the same control. Firefox was the only one paying it.
- Suite-level impact is unmeasured. It is `25% × how often your tests screenshot`, and only the end-to-end benchmark answers that; this PR measures the encoder in isolation.

**Question:** a no-op is a warning rather than an error here — if aports ever stops asking for the system copies we are already where we want to be, but the removal becomes dead code. Would you rather that were fatal so it cannot rot silently?
