### PR TITLE
perf(chromium): build headless-shell with PGO and ThinLTO by default — 42% gap becomes 12%

### DIFF
--- a/playwright/alpine-browsers/chromium-headless-shell/args.gn.headed.overlay
+++ b/playwright/alpine-browsers/chromium-headless-shell/args.gn.headed.overlay
@@ -85,6 +85,11 @@ use_cups = false
 enable_basic_printing = true
 enable_print_preview = true
 enable_vr = false
+# Deliberately still 0 while the headless overlay moved to 2. The 1.12x
+# geomean was measured on headless_shell; the headed target is a different and
+# substantially longer build, and turning this on there would be extrapolating
+# past the evidence onto the most expensive build we have. Measure it before
+# flipping it.
 chrome_pgo_phase = 0
 disable_fieldtrial_testing_config = true
 enable_nocompile_tests = false

--- a/playwright/alpine-browsers/chromium-headless-shell/args.gn.overlay
+++ b/playwright/alpine-browsers/chromium-headless-shell/args.gn.overlay
@@ -148,12 +148,41 @@ skia_use_dawn = false
 use_dawn = false
 
 # More aports-aligned defaults that headless_shell doesn't conflict with:
-chrome_pgo_phase = 0                       # no PGO (build wall-clock); aports same
+# PGO and ThinLTO, measured TOGETHER. Against Playwright's official build,
+# geomean and layout:
+#
+#   baseline       1.42 / 2.27
+#   PGO alone      1.28 / 1.89
+#   ThinLTO alone  1.31 / 1.89
+#   both           1.12 / 1.61   <- run 32650654039
+#
+# Super-additive: each knob alone recovers about a third of the gap, together
+# they recover roughly three quarters, and independent effects would have
+# predicted ~1.17-1.20. Neither single arm predicted 1.12, which is why they
+# had to be built together rather than reasoned about.
+#
+# The controls in that run are what make it readable: int_math and libm_fmod
+# both 1.00 (JIT output and musl's libm untouched), js_alloc 0.98,
+# locator_click and screenshot 1.00 because they are frame-cadence-bound.
+# Everything that moved is compiled Blink C++.
+#
+# The profile is a plain public download; apply-and-build fetches it and
+# injects pgo_data_path, which is the branch gn takes when the path is
+# non-empty — no depot_tools, no gsutil. Chromium's own default for our config
+# (is_official_build && !dcheck_always_on && is_linux) is ALREADY 2, so the
+# previous `0` is what kept PGO off rather than any absence of support.
+#
+# COST: ~38 h wall-clock, finishing at round 9 of 12 (build 32530923539). The
+# browser runs in every consumer's CI and time-to-tests for a prebuilt image is
+# ~entirely image pull, so the trade only makes sense in this direction. When
+# ITERATING on plumbing rather than publishing, set both back to 0/false — it
+# roughly halves the round trip and no plumbing question depends on them.
+chrome_pgo_phase = 2
 enable_vr = false                          # no VR/XR
 disable_fieldtrial_testing_config = true   # skip field-trial test configs
 enable_nocompile_tests = false             # no nocompile testing
 is_cfi = false                             # CFI off (no IFUNC support on alpine clang)
-use_thin_lto = false                       # aports same; is_official_build would default it ON
+use_thin_lto = true                        # see the PGO block above; measured together
 fatal_linker_warnings = false              # match aports — alpine's lld trips a few warnings
 safe_browsing_use_unrar = false            # no unrar (we don't ship)
 


### PR DESCRIPTION
The chromium residual has been the long thread of this session: after either perf knob our headless-shell still sat ~1.3x off Playwright's official build, and six candidates died along the way — the allocator, the fonts, musl's string routines, libc++ hardening, the orderfile, CFI. What survived every probe was a clean partition: everything running **compiled Blink C++** was ~1.6x, everything running **JIT-emitted machine code** was at parity. That pointed at codegen and left one untested lever, because the two knobs had only ever been built separately.

Built together ([32530923539](https://github.com/jclaveau/ci-prebuilds/actions/runs/32530923539)) and measured on one runner ([32650654039](https://github.com/jclaveau/ci-prebuilds/actions/runs/32650654039)):

| arm | geomean | layout |
|---|---|---|
| baseline | 1.42 | 2.27 |
| PGO alone | 1.28 | 1.89 |
| ThinLTO alone | 1.31 | 1.89 |
| **PGO + ThinLTO** | **1.12** | **1.61** |

The gap closes **42% → 12%**. Super-additive: each knob alone recovers about a third, together they recover roughly three quarters, and independent effects would have predicted ~1.17-1.20. Neither single arm predicted 1.12 — which is exactly why it had to be built rather than reasoned about.

The controls are what make it readable: `int_math` 1.00 and `libm_fmod` 1.00 (JIT output and musl's libm untouched), `js_alloc` 0.98, `locator_click` and `screenshot` 1.00 because they are frame-cadence-bound. Every metric that moved is compiled Blink C++ — layout 1.61, `goto_warm` 1.28, `dom_churn` 1.16, `click_force` 1.15 — the same population that read ~1.6x through every earlier probe.

**Cost: ~38 h wall-clock**, finishing at round 9 of 12. The browser runs in every consumer's CI while time-to-tests for a prebuilt image is ~entirely image pull, so the trade only makes sense in this direction. The comment records how to flip both back while iterating on plumbing, where no question depends on optimization level and it roughly halves the round trip.

Worth recording since it looked like a blocker: the monolithic ThinLTO link of `headless_shell` has no partial resume, so if it had needed more than one 5-hour round the whole round architecture could never have finished. It took 18 minutes.

**Out of scope, considered and not done:**
- The **headed** overlay stays at `chrome_pgo_phase = 0`, with a comment saying why. This was measured on `headless_shell`; headed is a different and substantially longer build, and flipping it would be extrapolating past the evidence onto the most expensive build we have.
- The residual 12% geomean / 61% layout is untouched. Both binaries report `151.0.7922.34`, so it is not version drift. What is left: alpine's clang 22 against official's 23, and whatever is structurally Google's — CFI, their own PGO profile rather than the public one, full bundling.

**Questions:**
- 38 h per publish is the real decision here, and it is an economics call rather than a technical one. Happy to land this behind a dispatch input instead of as the default if you would rather choose per build.
- `chs-latest` currently points at the ThinLTO-only experiment from the earlier round — predates this PR, but this is the natural moment to untangle it.
