### PR TITLE
fix(ci): resolve the global playwright under pnpm 11

### DIFF
--- a/.github/workflows/alpine-gap-probes.yml
+++ b/.github/workflows/alpine-gap-probes.yml
@@ -71,9 +71,7 @@ jobs:
           # both-roots loop and dropping the install fallback is exactly why the
           # three net-official-* jobs died with "Cannot find module 'playwright'"
           # in run 32073294621: neither root resolves it on the MS image.
-          for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-            [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-          done
+          NODE_PATH="$(sh "$GITHUB_WORKSPACE/playwright/scripts/global-node-path.sh")"
           export NODE_PATH
           node -e 'require("playwright")' 2>/dev/null \
             || npm install -g --no-fund --no-audit "playwright@${{ inputs.pw_version }}" >/dev/null 2>&1
@@ -105,9 +103,7 @@ jobs:
       - name: Probe bundled vs system libs
         working-directory: playwright/bench
         run: |
-          for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-            [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-          done
+          NODE_PATH="$(sh "$GITHUB_WORKSPACE/playwright/scripts/global-node-path.sh")"
           export NODE_PATH
           node -e 'require("playwright")' 2>/dev/null \
             || npm install -g --no-fund --no-audit "playwright@${{ inputs.pw_version }}" >/dev/null 2>&1
@@ -172,12 +168,11 @@ jobs:
               --env "PROBE_TARGET=$name" \
               --env "PW_VERSION=$PW_VERSION" \
               -v "$PWD/playwright/bench:/probe:ro" \
+              -v "$PWD/playwright/scripts:/pwscripts:ro" \
               -v "$PWD/opts-out:/out" \
               "$IMG" \
               sh -c '
-                for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                  [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-                done
+                NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
                 export NODE_PATH
                 node -e "require(\"playwright\")" 2>/dev/null \
                   || npm install -g --no-fund --no-audit "playwright@$PW_VERSION" >/dev/null 2>&1

--- a/.github/workflows/chromium-gap-probes.yml
+++ b/.github/workflows/chromium-gap-probes.yml
@@ -172,13 +172,12 @@ jobs:
           echo "::group::probe official"
           docker run --rm --env HOME=/root \
             -v "$PWD/playwright/bench:/probe:ro" \
+            -v "$PWD/playwright/scripts:/pwscripts:ro" \
             -v "$PWD/gap-out:/out" \
             --env "PW_VERSION=${PW}" \
             "$OFFICIAL" \
             sh -c '
-              for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-              done
+              NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
               export NODE_PATH
               node -e "require(\"playwright\")" 2>/dev/null \
                 || npm install -g --no-fund --no-audit \

--- a/.github/workflows/chs-perf-ab.yml
+++ b/.github/workflows/chs-perf-ab.yml
@@ -93,6 +93,7 @@ jobs:
               --env "PROBE_TARGET=${label}" \
               --env HOME=/root \
               -v "$PWD/playwright/bench:/probe:ro" \
+              -v "$PWD/playwright/scripts:/pwscripts:ro" \
               -v "$PWD/perf-out:/out" \
               --env "PW_VERSION=${PW}" \
               "$image" \
@@ -100,9 +101,7 @@ jobs:
                 # The reference image bakes playwright somewhere `npm root -g`
                 # alone does not always cover, so try both roots and install as
                 # a last resort — same shape as the probe job in test-and-publish.
-                for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                  [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-                done
+                NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
                 export NODE_PATH
                 node -e "require(\"playwright\")" 2>/dev/null \
                   || npm install -g --no-fund --no-audit "playwright@$PW_VERSION" >/dev/null 2>&1

--- a/.github/workflows/ff-perf-ab.yml
+++ b/.github/workflows/ff-perf-ab.yml
@@ -87,13 +87,12 @@ jobs:
               --env "PROBE_TARGET=${label}" \
               --env HOME=/root \
               -v "$PWD/playwright/bench:/probe:ro" \
+              -v "$PWD/playwright/scripts:/pwscripts:ro" \
               -v "$PWD/perf-out:/out" \
               --env "PW_VERSION=${PW}" \
               "$image" \
               sh -c '
-                for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                  [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-                done
+                NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
                 export NODE_PATH
                 node -e "require(\"playwright\")" 2>/dev/null \
                   || npm install -g --no-fund --no-audit "playwright@$PW_VERSION" >/dev/null 2>&1

--- a/.github/workflows/screenshot-encode-diagnosis.yml
+++ b/.github/workflows/screenshot-encode-diagnosis.yml
@@ -135,13 +135,12 @@ jobs:
               --env "PROBE_BROWSER=${BROWSER}" \
               --env HOME=/root \
               -v "$PWD/playwright/bench:/probe:ro" \
+              -v "$PWD/playwright/scripts:/pwscripts:ro" \
               -v "$PWD/perf-out:/out" \
               --env "PW_VERSION=${PW}" \
               "$image" \
               sh -c '
-                for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                  [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-                done
+                NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
                 export NODE_PATH
                 node -e "require(\"playwright\")" 2>/dev/null \
                   || npm install -g --no-fund --no-audit "playwright@$PW_VERSION" >/dev/null 2>&1

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1332,9 +1332,7 @@ jobs:
         run: |
           # `playwright` is installed globally in these images; the script is
           # CommonJS so this resolution applies (ESM ignores NODE_PATH).
-          for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-            [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-          done
+          NODE_PATH="$(sh "$GITHUB_WORKSPACE/playwright/scripts/global-node-path.sh")"
           export NODE_PATH
           node playwright/scripts/assert-browser-versions.cjs
 
@@ -1420,6 +1418,7 @@ jobs:
               --env "PROBE_TARGET=$target" \
               --env "PW_VERSION=$PW" \
               -v "$PWD/playwright/bench:/probe:ro" \
+              -v "$PWD/playwright/scripts:/pwscripts:ro" \
               -v "$PWD/perf-out:/out" \
               "$image" \
               sh -c '
@@ -1427,9 +1426,7 @@ jobs:
                 # ours, npm -g on the control), and the probe is CommonJS precisely so
                 # NODE_PATH resolution applies — ESM ignores NODE_PATH. The npm
                 # fallback covers a control image that stops baking it in.
-                for r in "$(pnpm root -g 2>/dev/null)" "$(npm root -g 2>/dev/null)"; do
-                  [ -n "$r" ] && NODE_PATH="${NODE_PATH:+$NODE_PATH:}$r"
-                done
+                NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
                 export NODE_PATH
                 node -e "require(\"playwright\")" 2>/dev/null \
                   || npm install -g --no-fund --no-audit "playwright@$PW_VERSION" >/dev/null 2>&1

--- a/playwright/scripts/global-node-path.sh
+++ b/playwright/scripts/global-node-path.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Echo a NODE_PATH that covers wherever `playwright` was installed globally.
+#
+# Usage:  export NODE_PATH="$(sh playwright/scripts/global-node-path.sh)"
+#
+# - `playwright` is a global install in these images, and every caller is
+#   CommonJS precisely so NODE_PATH resolution applies — ESM ignores it.
+# - Both package managers are tried: our images install it with pnpm, the
+#   official control image bakes it with npm.
+# - pnpm 11 moved the global store, which is what broke every caller at once
+#   when the v11 bump landed. `pnpm root -g` used to name the global
+#   node_modules directory itself; it now names its grandparent, with a
+#   content-addressed directory in between (`global/v11/<hash>/node_modules`).
+#   Each layout is matched on its own so that pnpm 10's reply does not also
+#   glob a package's OWN nested node_modules onto the path, where it could
+#   shadow a top-level install.
+pnpm_root="$(pnpm root -g 2>/dev/null)"
+case "$pnpm_root" in
+  */node_modules) set -- "$pnpm_root" ;;
+  *)              set -- "$pnpm_root"/*/node_modules ;;
+esac
+
+node_path=""
+for root in "$@" "$(npm root -g 2>/dev/null)"; do
+  if [ -d "$root" ]; then
+    node_path="${node_path:+$node_path:}$root"
+  fi
+done
+echo "$node_path"


### PR DESCRIPTION
Merging the pnpm v11 bump took main red in two waves, and this is the second one. The first was the image builds (`$PNPM_HOME/bin` not on PATH), already fixed on main in a6ff3d1. Once those went green, four jobs that had been *blocked behind* them surfaced with `Cannot find module 'playwright'`: `test-playwright-browser-versions` on both distros, `perf-chromium` and `perf-firefox`.

pnpm 11 moved the global store, so the `NODE_PATH` idiom we use everywhere stopped pointing at anything:

```
pnpm 10   pnpm root -g → /…/pnpm/global/5/node_modules      (IS the tree)
pnpm 11   pnpm root -g → /…/pnpm/global/v11                 (tree is at <that>/<hash>/node_modules)
```

I measured this in a container rather than trusting release notes, because the failure mode is quiet: neither the reported root nor root+`/node_modules` resolves under 11, and the bin turns out to be a shim script rather than a symlink, so it can't be derived from the CLI either.

## Why a shared script rather than nine edits

The idiom was copy-pasted **verbatim in nine places across six workflows**. That is the same shape as the aports pkgver rule, which drifted in two of its three copies and made every PW bump structurally red — fixing this in the four currently-red sites is how we'd get there again.

So it becomes one `playwright/scripts/global-node-path.sh`, matched per pnpm major so that 10's reply doesn't also glob a package's *own* nested `node_modules` onto the path where it could shadow a top-level install.

Two call shapes, because six of the nine run inside `docker run … sh -c '…'` where the repo isn't present:

- **container-side (6)** — mounted next to the `/probe` mount each one already carries.
- **runner-side (3)** — addressed through `$GITHUB_WORKSPACE`, not a relative path: `alpine-gap-probes`'s "Probe bundled vs system libs" sets `working-directory: playwright/bench`, so a relative path would have missed and I'd have shipped a third wave.

## Retrocompat

Verified against pnpm 11.23.0 and 10.34.5 in containers, plus a no-pnpm control that falls back to the npm root without crashing. So this is safe if `PNPM_VERSION` is ever pinned back — the same reason a6ff3d1 left the bare `$PNPM_HOME` on PATH.

## Reviewer questions

- Should the images export a usable `NODE_PATH` themselves instead? That would fix every *consumer* of the published images too, not just our CI — anyone doing `require('playwright')` against them hits exactly this. I didn't, because Docker can't set `ENV` from a `RUN` result and the pnpm 11 path contains a build-time hash. Worth a follow-up issue?
- The mount is named `/pwscripts`. If you'd rather it sat under the existing `/probe` mount I can move the script into `playwright/bench/` instead and drop six mount lines.

## Out of scope

- The stray `pnpm root -g` comments above the call sites are left as-is; they still describe the npm fallback accurately.
- `perf-chromium`/`perf-firefox` may have their own failures behind this one — they've never run to completion on this commit, so I can only say this unblocks them, not that they pass.