### PR TITLE
perf(firefox): preload mimalloc — closes the screenshot/launch/eval_rtt gap vs official

### DIFF
--- a/.github/workflows/ff-perf-ab.yml
+++ b/.github/workflows/ff-perf-ab.yml
@@ -134,7 +134,7 @@ jobs:
               nspr nss pipewire-libs libpulse libstdc++ libgcc \\
               gstreamer gst-plugins-base gst-plugins-good gst-libav \\
               opus libsecret libxslt double-conversion minizip crc32c \\
-              mimalloc2-insecure
+              mimalloc2-insecure mimalloc2 jemalloc
           COPY --from=${image} /firefox /ms-playwright/firefox-${FF_REV}/firefox
           RUN touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \\
            && chmod 755 /ms-playwright/firefox-${FF_REV}

--- a/.github/workflows/ff-perf-ab.yml
+++ b/.github/workflows/ff-perf-ab.yml
@@ -41,6 +41,14 @@ on:
         description: 'Playwright version to drive the probe'
         default: '1.62.1'
         type: string
+      preload_a:
+        description: 'LD_PRELOAD baked into arm A''s firefox shim (e.g. /usr/lib/libmimalloc-insecure.so.2)'
+        default: ''
+        type: string
+      preload_b:
+        description: 'LD_PRELOAD baked into arm B''s firefox shim, same form as preload_a'
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,6 +79,8 @@ jobs:
           LABEL_B: ${{ inputs.label_b }}
           FF_REV: ${{ inputs.ff_rev }}
           PW: ${{ inputs.pw_version }}
+          PRELOAD_A: ${{ inputs.preload_a }}
+          PRELOAD_B: ${{ inputs.preload_b }}
         run: |
           set -o pipefail
           mkdir -p perf-out && chmod 777 perf-out
@@ -103,8 +113,12 @@ jobs:
           }
 
           probe_one() {
-            local image="$1" label="$2"
+            local image="$1" label="$2" preload="$3"
             if [ "$image" = official ]; then
+              # No preload arm for official: noble carries no mimalloc, and the
+              # question the preload asks — can a general-purpose allocator
+              # stand in for the mozjemalloc we cannot build on musl — is only
+              # meaningful on our side.
               probe_official "$label"
               return
             fi
@@ -119,7 +133,8 @@ jobs:
               libvorbis libvpx libwebp libwebpdemux libxcomposite libxt mesa-gl \\
               nspr nss pipewire-libs libpulse libstdc++ libgcc \\
               gstreamer gst-plugins-base gst-plugins-good gst-libav \\
-              opus libsecret libxslt double-conversion minizip crc32c
+              opus libsecret libxslt double-conversion minizip crc32c \\
+              mimalloc2-insecure
           COPY --from=${image} /firefox /ms-playwright/firefox-${FF_REV}/firefox
           RUN touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \\
            && chmod 755 /ms-playwright/firefox-${FF_REV}
@@ -134,7 +149,7 @@ jobs:
            && printf '%s\\n' \\
                   '#!/bin/sh' \\
                   'DIR="\$(dirname "\$0")"' \\
-                  'ICU_DATA="\$DIR" exec "\$DIR/firefox.real" --remote-debugging-port=0 "\$@"' \\
+                  'LD_PRELOAD="${preload}" ICU_DATA="\$DIR" exec "\$DIR/firefox.real" --remote-debugging-port=0 "\$@"' \\
                 > /ms-playwright/firefox-${FF_REV}/firefox/firefox \\
            && chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox
           ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
@@ -145,6 +160,14 @@ jobs:
           RUN npm install -g --no-fund --no-audit playwright@${PW}
           EOF
             docker build -t "ff-probe-${label}:${{ github.run_id }}" -f /tmp/Dockerfile."${label}" /tmp
+            # A preload naming a path the image does not carry is silently
+            # ignored by the loader, so a typo would report a clean null result.
+            if [ -n "$preload" ]; then
+              docker run --rm "ff-probe-${label}:${{ github.run_id }}" \
+                test -f "$preload" \
+                || { echo "preload $preload absent from arm ${label}" >&2; exit 1; }
+              echo "arm ${label} preloads ${preload}"
+            fi
             # The probe is CommonJS precisely so NODE_PATH resolution applies to
             # the global playwright install — ESM ignores NODE_PATH.
             docker run --rm \
@@ -160,8 +183,8 @@ jobs:
             echo "::endgroup::"
           }
 
-          probe_one "$IMAGE_A" "$LABEL_A"
-          probe_one "$IMAGE_B" "$LABEL_B"
+          probe_one "$IMAGE_A" "$LABEL_A" "$PRELOAD_A"
+          probe_one "$IMAGE_B" "$LABEL_B" "$PRELOAD_B"
 
       - name: Report
         env:

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -35,7 +35,7 @@ RUN sudo apk add --no-cache \
         alsa-lib dbus-libs fontconfig glib gtk+3.0 harfbuzz \
         libdrm libevent libffi libjpeg-turbo libnotify libogg libtheora \
         libvorbis libvpx libwebp libwebpdemux libxcomposite libxt mesa-gl \
-        nspr nss pipewire-libs libpulse libstdc++ libgcc \
+        nspr nss pipewire-libs libpulse libstdc++ libgcc mimalloc2-insecure \
         libwpe libwpebackend-fdo gtk4.0 at-spi2-core cairo pango gdk-pixbuf \
         mesa-gles mesa-gbm mesa-dri-gallium mesa-vulkan-swrast \
         gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav \
@@ -67,7 +67,7 @@ COPY --from=ff-source /firefox /ms-playwright/firefox-${FF_REV}/firefox
 RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/firefox-${FF_REV}
 
-# Firefox launch shim — handles two musl-FF quirks:
+# Firefox launch shim — handles three musl-FF quirks:
 #
 # 1. ICU data file. aports builds firefox --with-system-icu; Alpine's
 #    libicudata.so.${maj} is a 12 KB stub and the real data file lives at
@@ -86,11 +86,26 @@ RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
 #    Tier-2 smoke does this from test code; the shim makes PW-driven launches
 #    get the flag transparently. Drop the flag once a build-side Juggler
 #    self-bootstrap fix lands in the producer.
+#
+# 3. The allocator. Playwright's own firefox links mozjemalloc — `nm -D` on
+#    its libxul leaves `malloc` undefined 0 times, ours 1. We cannot build
+#    mozjemalloc on musl: mozmemory_wrap.h declares free_impl/memalign_impl
+#    `noexcept(true)` to match glibc's __THROW, musl does not mark them, and
+#    every decl mismatches its previous one. So musl's malloc answered every
+#    allocation, and that — not the PNG encoder, not musl's string routines,
+#    not the missing PGO — was the whole gap against official: preloading
+#    mimalloc moves screenshot 0.69x -> 0.96x, launch 0.83x -> 1.02x and
+#    eval_rtt 0.86x -> 1.00x, while int_math and locator_click, which
+#    allocate nothing, stay identical (runs 32833439914, 32833725968).
+#    Scoped to the shim rather than ENV so it reaches firefox and its
+#    children and not the Node.js driving them, and so chromium's
+#    PartitionAlloc and webkit's bmalloc are left alone.
 RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
             /ms-playwright/firefox-${FF_REV}/firefox/firefox.real \
  && printf '%s\n' \
         '#!/bin/sh' \
         'DIR="$(dirname "$0")"' \
+        'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \
         'ICU_DATA="$DIR" exec "$DIR/firefox.real" --remote-debugging-port=0 "$@"' \
   | sudo tee /ms-playwright/firefox-${FF_REV}/firefox/firefox >/dev/null \
  && sudo chmod +x /ms-playwright/firefox-${FF_REV}/firefox/firefox

--- a/playwright/alpine-browsers/conformance/build-runner.sh
+++ b/playwright/alpine-browsers/conformance/build-runner.sh
@@ -188,6 +188,7 @@ RUN apk update && apk add --no-cache \\
     icu-libs icu-data-full libevent libffi libjpeg-turbo libnotify libogg \\
     libtheora libvorbis libvpx libwebp libwebp-tools libwebpdemux libxcomposite \\
     libxt mesa-gl mesa-dri-gallium nspr nss pipewire-libs libpulse \\
+    mimalloc2-insecure \\
     ttf-freefont xvfb xvfb-run jq \\
     ffmpeg-libs \\
     at-spi2-core libatk-1.0 cairo gdk-pixbuf pango pixman fribidi brotli bzip2 \\
@@ -210,11 +211,15 @@ RUN bash /tmp/strip-bundled-libs.sh /ms-playwright/firefox-${ARTIFACT_REV}/firef
 # browsertype-connect run-server tests launch FF without it → 38min hang. Wrap the
 # binary so the arg is always present regardless of PW's filtering — the security
 # filter stays fully intact. Dedup guard avoids double-passing on paths that add it.
+# The LD_PRELOAD mirrors playwright/Dockerfile.alpine's shim (quirk 3 there):
+# conformance has to exercise the allocator we actually ship, or the suite
+# validates a build nobody runs.
 RUN FFBIN=/ms-playwright/firefox-${ARTIFACT_REV}/firefox/firefox \\
  && mv "\$FFBIN" "\$FFBIN.real" \\
  && printf '%s\\n' \\
       '#!/bin/sh' \\
       'D=\$(dirname "\$0")' \\
+      'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \\
       'case " \$* " in' \\
       '  *" --remote-debugging-port"*) exec "\$D/firefox.real" "\$@" ;;' \\
       '  *) exec "\$D/firefox.real" --remote-debugging-port=0 "\$@" ;;' \\


### PR DESCRIPTION
Our firefox has been measurably slower than Playwright's own on three metrics for months — screenshot 0.69x, launch 0.83x, layout 0.86x — and I had been attributing it to the wrong things. This closes it.

## Why

`nm -D` on the two shipped `libxul.so` (both firefox 153.0, so version-matched) says official leaves `malloc` **undefined 0 times** and ours **1**: Playwright's build links mozjemalloc, ours calls out to musl's allocator for every allocation firefox makes.

We can't follow them. `--enable-jemalloc` doesn't compile against musl — `mozmemory_wrap.h` declares `free_impl`/`memalign_impl` `noexcept(true)` to match glibc's `__THROW`, musl doesn't mark them, and every declaration mismatches its previous one (run 32800234529, died ~2 min into `memory/`). aports' `--disable-jemalloc` is a musl **requirement**, not performance left on the table. So the only way to ask the question is to stand a general-purpose allocator in at runtime.

## What it buys

Same image both arms, same runner, only the shim differing (run 32833439914), then against official (run 32833725968):

| metric | before | after |
|---|---:|---:|
| screenshot | 0.69x | **0.96x** |
| launch | 0.83x | **1.02x** |
| eval_rtt | 0.86x | **1.00x** |

`int_math` and `locator_click` — the rows that allocate nothing — come back identical to the millisecond on both arms, which is what makes the rest readable as an allocator measurement rather than runner luck. The mimalloc arm has been measured twice and agrees on the two rows carrying the claim (screenshot 224.5 / 218.4 ms, launch 839.1 / 837.3 ms).

**`layout` is deliberately not quoted.** It read 70 ms then 98 ms across those same two runs — a 40% swing — so its ratio sits inside its own noise. I'd rather leave it unclaimed than bank it.

## What this rules out

- **Not the PNG encoder.** #102 already made our bytes byte-identical to official's and the screenshot time did not follow. That hypothesis is now dead twice over.
- **Not musl's string routines**, despite `nm -D` showing the same shape of difference (official resolves memcpy/memmove/memset/memcmp/strlen internally, we import all five). An AVX2 shim answering all five moved nothing — every row inside the baseline drift — with a marker file proving it loaded into 34 processes. The import difference is real; the cost is not.
- **Probably not PGO.** aports' PGO recipe emits a jarlog and reorders `omni.ja`; official's `omni.ja` is plain alphabetical, 2458 entries, identical ordering to ours. So official very likely isn't PGO'd, and building it would put us *past* them rather than close a gap. It stays unbuilt.

## Choices I'd like a second opinion on

- **`mimalloc2-insecure` vs `mimalloc2` vs `jemalloc`.** I shipped the insecure variant because it's what aports itself preloads for the firefox build, but that's inherited, not measured. A jemalloc arm is running now (it's the closer analogue of mozjemalloc); happy to swap if it wins. "insecure" here means `MI_SECURE=0` — no guard pages, no randomised freelists — which is upstream mimalloc's default, but the name deserves a conscious decision in a published image.
- **Scoping.** The preload is in the firefox shim, not `ENV`, so it reaches firefox and its children but not the Node.js driving them, and chromium's PartitionAlloc / webkit's bmalloc are untouched. That seemed clearly right; say if you'd rather it were image-wide.

## Out of scope

Not touched here: the `--enable-hardening` question (an Alpine tax Mozilla doesn't pay, worth one build to test), and libxul shipping 34 MB of `.debug_*` + `.symtab` that official strips — that's image size, not speed, and belongs in its own change.

The conformance runner gets the same preload line, because a suite exercising a different allocator than the one we ship validates a build nobody runs. That's what the CI here has to confirm before this lands.


---

## Update — both open questions answered by measurement

**Allocator choice: `mimalloc2-insecure` confirmed, keeping it.**

vs `jemalloc` (run 32834079973) — effectively a tie, no swap warranted:

| metric | mimalloc-insecure | jemalloc |
|---|---:|---:|
| screenshot | 205.8 | 222.2 |
| launch | 801.7 | 830.7 |
| eval_rtt | 371.8 | 390.8 |
| goto_warm | 33.7 | 30.2 |
| context_page | 229.6 | 224.3 |

mimalloc leads the rows that carry the claim, but screenshot's own spread across four mimalloc runs is 205.8–237.3 (15%), and jemalloc's 222.2 sits inside it. Calling this a tie rather than a win.

vs `mimalloc2` (secure) (run 32834354468) — **not** a tie, insecure wins clearly:

| metric | mi-insecure | mi-secure |
|---|---:|---:|
| context_page | **215.1** | 252.0 |
| dom_churn | **31** | 36 |
| eval_rtt | **333.8** | 380.1 |
| launch | **776.8** | 865.9 |
| goto_cold | **238.3** | 264.1 |
| goto_warm | 31.4 | **26.8** |
| *int_math* (control) | 34 | 35 |
| *libm_fmod* (control) | 83 | 83 |

−10 to −15% on every allocation-heavy row, controls flat. The secure variant's guard pages and randomised freelists cost real time here. So the insecure variant is now a measured choice rather than one inherited from aports' build recipe.

**Scoping: unchanged**, still shim-local rather than `ENV`.

## Correction on how this is being validated

`conformance-firefox` is dispatch-gated and shows **SKIPPED** on `pull_request`, as do `build-firefox` and `smoke-firefox`. This PR's green checks are the docker/tooling matrix, not the browser suite — they do not validate the allocator. Dispatched conformance explicitly against this branch instead (run 32834617430), so the runner is built from this PR's `build-runner.sh` and therefore carries the preload. That run is the gate for merging, not the PR's own checks.

## Note on `layout`

Across five runs it reads 70, 70, 98, 99, 102 ms — bimodal, not noisy-around-a-mean. Whatever that is, it is not something this change should be credited or blamed for, so no ratio is quoted for it anywhere above.
