### PR TITLE
perf(firefox): strip ELF symbol tables, and hash bundle-dist.sh so it actually ships

### DIFF
--- a/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
+++ b/.github/workflows/playwright-alpine-browsers-prebuilt-base.yml
@@ -56,17 +56,10 @@ jobs:
           echo "firefox_revision=$REV" >> "$GITHUB_OUTPUT"
           echo "firefox_version=$VER" >> "$GITHUB_OUTPUT"
           echo "PW v${PW_VERSION} → firefox revision=${REV} browserVersion=${VER}"
-          # Patch-set hash — MUST match playwright-alpine-browsers.yml's pins step
-          # (the consumer's auto-select checks prebuilt-base-ff-<rev>-<hash>). Same
-          # file list = same tag, so a source-only patch reseeds the base instead
-          # of silently reusing a stale one. Excludes apply-and-build-iter.sh.
-          PATCHSET_HASH=$(cat \
-            playwright/alpine-browsers/versions.env \
-            playwright/alpine-browsers/firefox/scripts/apply-and-build.sh \
-            playwright/alpine-browsers/firefox/scripts/fetch-aports.sh \
-            playwright/alpine-browsers/firefox/scripts/fetch-pw-patches.sh \
-            playwright/alpine-browsers/firefox/mozconfig.overlay \
-            | sha256sum | cut -c1-12)
+          # Content-addresses the base on the FF patch set so a source-only
+          # patch reseeds it instead of reusing a stale one. Shared with the
+          # other workflow's pins step — both MUST agree, see the script.
+          PATCHSET_HASH=$(bash playwright/alpine-browsers/firefox/patchset-hash.sh)
           echo "patchset_hash=$PATCHSET_HASH" >> "$GITHUB_OUTPUT"
           echo "FF patch-set hash=${PATCHSET_HASH}"
 

--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -266,20 +266,10 @@ jobs:
           echo "firefox_revision=$REV" >> "$GITHUB_OUTPUT"
           echo "firefox_version=$VER" >> "$GITHUB_OUTPUT"
           echo "PW v${PW_VERSION} → firefox revision=${REV} browserVersion=${VER}"
-          # Content-address the prebuilt-base on the FF patch SET, not just PW's
-          # rev. A source-only patch (e.g. the Juggler location fix in
-          # apply-and-build.sh) leaves the rev unchanged, so a rev-only base tag
-          # lets the iter path reuse a stale pre-patch base and ship an unpatched
-          # ff-latest (shipped exactly that 2026-07-28). Hashing the files baked
-          # INTO the base forces a cold reseed whenever the patch set changes.
-          # Excludes apply-and-build-iter.sh (applied at iter time, not baked in).
-          PATCHSET_HASH=$(cat \
-            playwright/alpine-browsers/versions.env \
-            playwright/alpine-browsers/firefox/scripts/apply-and-build.sh \
-            playwright/alpine-browsers/firefox/scripts/fetch-aports.sh \
-            playwright/alpine-browsers/firefox/scripts/fetch-pw-patches.sh \
-            playwright/alpine-browsers/firefox/mozconfig.overlay \
-            | sha256sum | cut -c1-12)
+          # Content-addresses the base on the FF patch set so a source-only
+          # patch reseeds it instead of reusing a stale one. Shared with the
+          # other workflow's pins step — both MUST agree, see the script.
+          PATCHSET_HASH=$(bash playwright/alpine-browsers/firefox/patchset-hash.sh)
           echo "patchset_hash=$PATCHSET_HASH" >> "$GITHUB_OUTPUT"
           echo "FF patch-set hash=${PATCHSET_HASH}"
 

--- a/.github/workflows/tests-firefox.yml
+++ b/.github/workflows/tests-firefox.yml
@@ -1,0 +1,36 @@
+name: tests-firefox
+
+# Cheap consistency guards for the firefox producer's build scripts. Runs in
+# seconds — catches a patch-set that would silently reuse a stale prebuilt-base
+# without waiting for the ~5h producer build to ship nothing.
+#
+# Separate from tests-aports, which is scoped to the chromium pin pair.
+
+on:
+  pull_request:
+    paths:
+      - 'playwright/alpine-browsers/firefox/**'
+      - 'playwright/alpine-browsers/versions.env'
+      - 'playwright/alpine-browsers/Dockerfile.prebuilt-base'
+      - 'tests/firefox/**'
+      - '.github/workflows/playwright-alpine-browsers.yml'
+      - '.github/workflows/playwright-alpine-browsers-prebuilt-base.yml'
+      - '.github/workflows/tests-firefox.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'playwright/alpine-browsers/firefox/**'
+      - 'playwright/alpine-browsers/versions.env'
+      - 'playwright/alpine-browsers/Dockerfile.prebuilt-base'
+      - 'tests/firefox/**'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: prebuilt-base patch-set hash unit test
+        run: bash tests/firefox/test-patchset-hash.sh

--- a/playwright/alpine-browsers/Dockerfile
+++ b/playwright/alpine-browsers/Dockerfile
@@ -25,7 +25,7 @@ FROM alpine:${ALPINE_VERSION} AS firefox-builder
 # `_llvmver` (read by apply-and-build.sh at build time, not hard-coded here).
 RUN apk add --no-cache \
         bash curl git patch patchutils tar xz gzip jq gettext-envsubst make sccache \
-        alsa-lib-dev automake bsd-compat-headers cargo cbindgen \
+        alsa-lib-dev automake binutils bsd-compat-headers cargo cbindgen \
         clang22 clang22-libclang clang22-dev compiler-rt \
         dbus dbus-dev gettext gtk+3.0-dev hunspell-dev icu-dev icu-data-full \
         libevent-dev libffi-dev libjpeg-turbo-dev libnotify-dev libogg-dev \

--- a/playwright/alpine-browsers/Dockerfile.prebuilt-base
+++ b/playwright/alpine-browsers/Dockerfile.prebuilt-base
@@ -19,7 +19,7 @@ FROM alpine:${ALPINE_VERSION} AS firefox-builder
 # Same tool deps as the regular Dockerfile. Keep this in sync.
 RUN apk add --no-cache \
         bash curl git patch patchutils tar xz gzip jq gettext-envsubst make sccache \
-        alsa-lib-dev automake bsd-compat-headers cargo cbindgen \
+        alsa-lib-dev automake binutils bsd-compat-headers cargo cbindgen \
         clang22 clang22-libclang clang22-dev compiler-rt \
         dbus dbus-dev gettext gtk+3.0-dev hunspell-dev icu-dev \
         libevent-dev libffi-dev libjpeg-turbo-dev libnotify-dev libogg-dev \

--- a/playwright/alpine-browsers/firefox/patchset-hash.sh
+++ b/playwright/alpine-browsers/firefox/patchset-hash.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Content-address the FF prebuilt-base on its patch SET, not just PW's rev.
+#
+# A source-only patch (the Juggler location fix, the bundle-dist strip pass)
+# leaves PW's firefox revision unchanged, so a rev-only base tag lets the iter
+# path reuse a stale pre-patch base and ship an unpatched ff-latest. We shipped
+# exactly that on 2026-07-28.
+#
+# The set to hash is "whatever Dockerfile.prebuilt-base bakes into the image":
+#
+#   COPY versions.env              /work/versions.env
+#   COPY firefox/scripts           /work/firefox/scripts
+#   COPY firefox/mozconfig.overlay /work/firefox/mozconfig.overlay
+#
+# It is derived from the directory rather than hand-listed. The hand-listed
+# version silently omitted bundle-dist.sh, which is baked in and does affect
+# the artifact — so edits to it reused a stale base and never shipped.
+#
+# Lives outside firefox/scripts/ on purpose: a file in there would be baked in
+# and would hash itself, reseeding a ~5h build whenever this logic changed.
+#
+# Both playwright-alpine-browsers.yml and
+# playwright-alpine-browsers-prebuilt-base.yml call this. They MUST agree — the
+# consumer's auto-select looks up prebuilt-base-ff-<rev>-<hash>, so two
+# implementations that drift apart mean a base that is never found.
+#
+# Usage: patchset-hash.sh [repo_root]   (default: cwd)
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+BROWSERS="$ROOT/playwright/alpine-browsers"
+
+# apply-and-build-iter.sh is deliberately out: it runs at iter time against an
+# already-seeded base, so changing it must not force a cold reseed.
+mapfile -t FILES < <(
+  {
+    printf '%s\n' "$BROWSERS/versions.env" "$BROWSERS/firefox/mozconfig.overlay"
+    find "$BROWSERS/firefox/scripts" -type f ! -name 'apply-and-build-iter.sh'
+  } | LC_ALL=C sort
+)
+
+# An empty or short list would still produce a stable hash, and would silently
+# content-address the base on nothing. Fail instead.
+if [ "${#FILES[@]}" -lt 5 ]; then
+  echo "patchset-hash: expected >=5 files, found ${#FILES[@]}" >&2
+  printf '  %s\n' "${FILES[@]}" >&2
+  exit 1
+fi
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || { echo "patchset-hash: missing $f" >&2; exit 1; }
+done
+
+cat "${FILES[@]}" | sha256sum | cut -c1-12

--- a/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh
+++ b/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh
@@ -103,4 +103,34 @@ if [ -n "$missing" ]; then
   ldd "$DST/firefox" 2>&1 | head -30 >&2
   exit 1
 fi
+# Strip ELF symbol tables. aports' mozconfig sets --disable-strip, because a
+# distro builds symbols here and strips them in package() -- which we never
+# run. So libxul ships .symtab + .strtab: 51.8 MB of the bundle's 380 MB.
+# Mozilla's own libxul carries neither, and our WebKit dist is already stripped
+# the same way in webkit/Dockerfile.finalize, so this is parity on both sides
+# rather than a new tradeoff. Neither section is SHF_ALLOC, so nothing leaves
+# the runtime image; .dynsym and the RPATH=$ORIGIN set above are untouched.
+#
+# Producer-side on purpose: the conformance runner builds from this artifact,
+# so what we measure is what we ship.
+#
+# The ELF-magic gate is load-bearing -- icudt*.dat (33 MB) sits in this same
+# directory and `strip` must never be handed it. `du -sk` because the builder
+# is busybox, which has no `du -b`.
+echo "===== Stripping ELF symbol tables ====="
+strip_before=$(du -sk "$DST" | cut -f1)
+stripped=0
+while IFS= read -r f; do
+  [ "$(od -An -N4 -tx1 < "$f" | tr -d ' \n')" = "7f454c46" ] || continue
+  strip --strip-all "$f" 2>/dev/null && stripped=$((stripped + 1))
+done < <(find "$DST" -type f)
+strip_after=$(du -sk "$DST" | cut -f1)
+echo "===== Stripped $stripped ELFs: $((strip_before / 1024)) -> $((strip_after / 1024)) MiB ====="
+
+# A strip that cost us a loadable artifact must fail here, not at consumer run.
+if ldd "$DST/libxul.so" 2>&1 | grep -q 'not found'; then
+  echo "ERROR: libxul.so has unresolved deps after strip" >&2
+  exit 1
+fi
+
 echo "===== Self-contained artifact: $(du -sh "$DST" | cut -f1) ====="

--- a/tests/firefox/test-patchset-hash.sh
+++ b/tests/firefox/test-patchset-hash.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Unit test for the shared FF prebuilt-base patch-set hash.
+#
+# Exists because the rule was hand-listed in two workflows and the list omitted
+# bundle-dist.sh — which IS baked into the base and DOES change the artifact.
+# Editing it therefore reused a stale base and shipped nothing, the same class
+# of miss that shipped an unpatched ff-latest on 2026-07-28.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+HASHER="$ROOT/playwright/alpine-browsers/firefox/patchset-hash.sh"
+
+failures=0
+checks=0
+
+fail() { echo "FAIL: $1" >&2; failures=$((failures + 1)); }
+check() { checks=$((checks + 1)); }
+
+# A scratch copy we can mutate, so the tests exercise the real script against a
+# real tree instead of asserting against its source.
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/playwright/alpine-browsers"
+cp -a "$ROOT/playwright/alpine-browsers/versions.env" \
+      "$scratch/playwright/alpine-browsers/"
+cp -a "$ROOT/playwright/alpine-browsers/firefox" \
+      "$scratch/playwright/alpine-browsers/"
+
+baseline=$(bash "$HASHER" "$scratch")
+
+check
+if ! [[ "$baseline" =~ ^[0-9a-f]{12}$ ]]; then
+  fail "hash is not 12 hex chars: '$baseline'"
+fi
+
+# The regression under test: bundle-dist.sh must be inside the hashed set.
+check
+echo '# mutation' >> "$scratch/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh"
+if [ "$(bash "$HASHER" "$scratch")" = "$baseline" ]; then
+  fail "editing bundle-dist.sh did not change the hash — a stale base would be reused"
+fi
+git -C "$ROOT" show HEAD:playwright/alpine-browsers/firefox/scripts/bundle-dist.sh \
+  > "$scratch/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh" 2>/dev/null \
+  || cp -a "$ROOT/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh" \
+           "$scratch/playwright/alpine-browsers/firefox/scripts/bundle-dist.sh"
+
+# ...and the iter script must stay outside it: it runs against an already-seeded
+# base, so touching it must not force a ~5h cold reseed.
+check
+restored=$(bash "$HASHER" "$scratch")
+echo '# mutation' >> "$scratch/playwright/alpine-browsers/firefox/scripts/apply-and-build-iter.sh"
+if [ "$(bash "$HASHER" "$scratch")" != "$restored" ]; then
+  fail "editing apply-and-build-iter.sh changed the hash — that forces a needless cold reseed"
+fi
+
+# Every file the base image bakes in must be hashed. If a COPY is added to
+# Dockerfile.prebuilt-base, this fails and the hasher has to be revisited.
+check
+copies=$(grep -E '^COPY ' "$ROOT/playwright/alpine-browsers/Dockerfile.prebuilt-base" \
+         | awk '{print $2}' | LC_ALL=C sort | paste -sd,)
+expected="firefox/mozconfig.overlay,firefox/scripts,versions.env"
+if [ "$copies" != "$expected" ]; then
+  fail "Dockerfile.prebuilt-base COPY set changed: '$copies' != '$expected' — patchset-hash.sh may now miss a baked-in file"
+fi
+
+# Neither workflow may re-implement the rule inline; that is how the two copies
+# drifted apart in the first place.
+for wf in playwright-alpine-browsers.yml playwright-alpine-browsers-prebuilt-base.yml; do
+  check
+  if ! grep -q 'patchset-hash.sh' "$ROOT/.github/workflows/$wf"; then
+    fail "$wf does not call the shared patchset-hash.sh"
+  fi
+  check
+  if grep -q 'PATCHSET_HASH=$(cat' "$ROOT/.github/workflows/$wf"; then
+    fail "$wf still computes the patch-set hash inline"
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "patchset-hash: $failures/$checks checks failed" >&2
+  exit 1
+fi
+echo "patchset-hash: $checks checks passed"


### PR DESCRIPTION
Two things, one of which I only found because of the other.

## The strip

I went looking for the 34 MB of DWARF I claimed was in `libxul.so` last session. There is none — `--disable-debug-symbols` is already in aports' mozconfig and it works. What is there is the **symbol table**: `.strtab` 41.2 MB + `.symtab` 10.5 MB, 51.8 MB of a 380 MB bundle.

That is because aports sets `--disable-strip` — a distro builds symbols here and strips them in `package()`, which we never run since we call `./mach build` directly. Mozilla's own `libxul` in `mcr.microsoft.com/playwright:v1.62.1-noble` carries neither section, and our WebKit dist is already stripped exactly this way in `webkit/Dockerfile.finalize`. Firefox was the last unstripped bundle, so this is parity on both sides rather than a new tradeoff.

Measured on the published `sha-97bc388` image:

| | before | after |
|---|---:|---:|
| on disk | 380 MB | 325 MB |
| compressed (what a pull costs) | 126.4 MB | 118.0 MB |

**The honest number is the 8.4 MB, not the 52 MB** — symbol tables compress well. I'd rather say that up front than have you find it.

Verified before/after against that image: `firefox --version` still reports `153.0` (the Tier-1 assert), Playwright drives it, and a PNG screenshot comes back byte-for-byte the same 8511 bytes.

## The thing I found on the way

The strip lives in `bundle-dist.sh` — and **`bundle-dist.sh` was not in the prebuilt-base patch-set hash.** That hash exists so a source-only patch reseeds the base instead of reusing a stale one; its own comment says it hashes "the files baked INTO the base", and `Dockerfile.prebuilt-base` bakes the whole directory via `COPY firefox/scripts`. The list was hand-written in two workflows and just missed this file.

So my strip would have gone green having shipped nothing — the same failure that shipped an unpatched `ff-latest` on 2026-07-28, still open for this one file. It is a prerequisite, so it is the first commit.

The set is now derived from the directory in one script both workflows call, instead of hand-listed twice. `apply-and-build-iter.sh` stays excluded: it runs against an already-seeded base, so touching it must not force a ~5h cold reseed.

The test pins all three claims — editing `bundle-dist.sh` moves the hash, editing the iter script does not, and neither workflow re-implements the rule inline. It fails against the old hand-listed rule and passes against this one; I checked both directions rather than trusting the green.

## Retrocompat

The first commit **changes the patch-set hash**, so the next FF build is a cold reseed (~5h) regardless of the strip. It was going to be cold anyway once `bundle-dist.sh` entered the hash — there is no ordering that avoids it.

## Out of scope

- `--enable-hardening`: you asked me to try it; it is **already on** via aports' mozconfig, so there is nothing to add. The arm worth running is the inverse, hardening *off*, and that is a build-flag change I did not want to bundle into a size PR.
- Whether the other browsers' patch-set hashes have the same hand-listed gap. Firefox is the only one with this base-reseed mechanism, but I did not audit chromium/webkit for an analogous omission.

## For you

- The `du -sk`/busybox and ELF-magic details are in the script comments; I tested the block under `alpine:edge` busybox specifically, not just my host GNU tools.
- Do you want the hardening-off arm dispatched on `ff-perf-ab` next, or is the allocator win enough for now?
