### PR TITLE
chore(webkit): track the capture-permission probe that found the camera/mic root cause

### DIFF
--- a/.github/workflows/pw-conformance.yml
+++ b/.github/workflows/pw-conformance.yml
@@ -136,6 +136,8 @@ jobs:
             # Root-caused via iter 29565116253 bucket-C + 3-agent source dive.
             SECURITY_FLAGS="$SECURITY_FLAGS --security-opt apparmor=unconfined --cap-add SYS_ADMIN --cap-add NET_ADMIN"
             EXTRA_ENV="-e WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 -e WEBKIT_FORCE_SANDBOX=0"
+            # webkit/probes/run-capture-probe.sh mirrors this block so a local
+            # probe measures the same browser CI does — change both together.
           fi
           if [ "$BROWSER" = "chromium" ]; then
             # chr-fs (and chs-fs) are DCHECK_ALWAYS_ON builds. Chrome raises a

--- a/playwright/alpine-browsers/webkit/probes/capture-permissions.cjs
+++ b/playwright/alpine-browsers/webkit/probes/capture-permissions.cjs
@@ -1,0 +1,122 @@
+// Does this WebKit artifact honour Browser.grantPermissions for camera and
+// microphone? Prints one row per grant state so a run can be diffed against the
+// official image.
+//
+// Reports BOTH navigator.permissions.query and getUserMedia on purpose: they
+// travel different paths through PW's patches, and the whole camera/mic
+// investigation turned on the fact that query agreed with official on every row
+// while getUserMedia did not. A probe that only called getUserMedia would have
+// said "permissions are broken" and sent the next person to the wrong layer.
+//
+// Serves over http://localhost: navigator.mediaDevices is undefined outside a
+// secure context, and about:blank does not qualify. Testing there measures the
+// secure-context rule rather than the artifact.
+
+const http = require('http');
+const { webkit } = require('playwright-core');
+
+const GRANT_STATES = [
+  { label: 'none', permissions: [] },
+  { label: 'camera-only', permissions: ['camera'] },
+  { label: 'camera+mic', permissions: ['camera', 'microphone'] },
+];
+
+async function queryPermissions(page) {
+  return await page.evaluate(async () => {
+    const states = {};
+    for (const name of ['camera', 'microphone']) {
+      try {
+        states[name] = (await navigator.permissions.query({ name })).state;
+      } catch (error) {
+        states[name] = 'ERR ' + error.name;
+      }
+    }
+    return states;
+  });
+}
+
+async function getUserMedia(page, constraints) {
+  return await page.evaluate(async requested => {
+    if (!navigator.mediaDevices) {
+      return 'no navigator.mediaDevices';
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(requested);
+      return stream.getTracks().map(track => track.kind).sort().join('+');
+    } catch (error) {
+      return error.name;
+    }
+  }, constraints);
+}
+
+async function enumerateDevices(page) {
+  return await page.evaluate(async () => {
+    if (!navigator.mediaDevices) {
+      return [];
+    }
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.map(device => device.kind + '|' + device.label);
+  });
+}
+
+(async () => {
+  const server = http.createServer((_, response) => {
+    response.setHeader('content-type', 'text/html');
+    response.end('<h1>capture-permissions probe</h1>');
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const origin = 'http://localhost:' + server.address().port;
+
+  const browser = await webkit.launch();
+  console.log('browser  ' + browser.version());
+  console.log('origin   ' + origin);
+  console.log('');
+  console.log('grant         query(camera/mic)  video+audio      video            audio');
+  console.log('------------  -----------------  ---------------  ---------------  ---------------');
+
+  for (const { label, permissions } of GRANT_STATES) {
+    // A fresh context per CELL, not per row. grantPermissions replaces the set
+    // for an origin so a stale grant would silently pass the next row, and
+    // repeated getUserMedia calls on one ungranted page take the browser down —
+    // official dies on the third. Isolating each cell is also how the PW tests
+    // this probe mirrors are written.
+    const cell = async constraints => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await page.goto(origin + '/');
+      if (permissions.length) {
+        await context.grantPermissions(permissions, { origin });
+      }
+      const result = { query: await queryPermissions(page) };
+      result.media = constraints ? await getUserMedia(page, constraints) : null;
+      // Labels stay blank until capture has actually been granted, so this
+      // has to run after getUserMedia on the same page, not on a fresh one.
+      result.devices = await enumerateDevices(page);
+      await context.close();
+      return result;
+    };
+
+    const both = await cell({ video: true, audio: true });
+    const video = await cell({ video: true });
+    const audio = await cell({ audio: true });
+
+    console.log(
+      label.padEnd(14)
+      + (both.query.camera + '/' + both.query.microphone).padEnd(19)
+      + both.media.padEnd(17) + video.media.padEnd(17) + audio.media);
+
+    if (label === 'camera+mic') {
+      console.log('');
+      console.log('devices after a granted capture:');
+      for (const device of both.devices) {
+        console.log('  ' + device);
+      }
+    }
+  }
+
+  await browser.close();
+  server.close();
+})().catch(error => {
+  console.error('probe failed:', error);
+  process.exit(1);
+});

--- a/playwright/alpine-browsers/webkit/probes/run-capture-probe.sh
+++ b/playwright/alpine-browsers/webkit/probes/run-capture-probe.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Run a probe script against a WebKit artifact, or against Playwright's own
+# image as the control.
+#
+#   ./run-capture-probe.sh wk-gtk-sha-<sha>          # one of ours
+#   ./run-capture-probe.sh official                  # PW's published image
+#   ./run-capture-probe.sh official capture-permissions.cjs
+#
+# Exists because the answer depends entirely on the environment, and two ways of
+# getting it wrong both look like a browser bug:
+#
+#   - The sandbox escape hatch is WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS (plus
+#     WEBKIT_FORCE_SANDBOX=0). `WEBKIT_DISABLE_SANDBOX=1` is a spelling WebKit
+#     silently ignores, so bwrap stays LIVE and enumerateDevices CRASHES the
+#     page — which reads as a capture bug and is not one. That typo already cost
+#     this repo the file-upload and download residuals once.
+#   - Without the GST_* vars the GStreamer plugins are installed but never
+#     discovered, and capture looks structurally broken. Same three values
+#     conformance/build-runner.sh bakes in.
+#
+# Keep this in step with the EXTRA_ENV / SECURITY_FLAGS block in
+# .github/workflows/pw-conformance.yml — a probe that does not match the runner
+# is measuring a different browser than CI is.
+
+set -euo pipefail
+
+TARGET="${1:?usage: run-capture-probe.sh <wk-tag|official> [probe.cjs]}"
+PROBE="${2:-capture-permissions.cjs}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Any image carrying the musl runtime deps our artifacts need. `edge` is the
+# consumer image built from this repo's main.
+PROBE_BASE="${PROBE_BASE:-ghcr.io/jclaveau/alpine-dood-playwright:edge}"
+PW_VERSION="${PW_VERSION:-1.62.1}"
+OFFICIAL_IMAGE="${OFFICIAL_IMAGE:-mcr.microsoft.com/playwright:v${PW_VERSION}-noble}"
+WK_PACKAGE="${WK_PACKAGE:-ghcr.io/jclaveau/playwright-alpine-browsers}"
+
+[ -f "$HERE/$PROBE" ] || { echo "no such probe: $HERE/$PROBE" >&2; exit 1; }
+
+# `official` runs unmodified — it already ships its own webkit and playwright.
+# Our artifacts are payload images with no shell, so they are staged onto
+# PROBE_BASE by replacing the whole minibrowser-wpe directory. Whole-directory,
+# never file-by-file: the layout is FLAT (every .so beside MiniBrowser with
+# RPATH=$ORIGIN), and assuming PW's nested lib/ layout has cost rounds before.
+if [ "$TARGET" = "official" ]; then
+  IMAGE="probe-official:${PW_VERSION}"
+  WORKDIR=/root/pwc
+  build_context=$(mktemp -d)
+  trap 'rm -rf "$build_context"' EXIT
+  cat > "$build_context/Dockerfile" <<EOF
+FROM ${OFFICIAL_IMAGE}
+WORKDIR ${WORKDIR}
+RUN npm init -y >/dev/null && npm i playwright-core@${PW_VERSION} >/dev/null 2>&1
+EOF
+  docker build -q -t "$IMAGE" "$build_context" >/dev/null
+else
+  IMAGE="probe-${TARGET}"
+  WORKDIR=/home/runner/pwc
+  # The revision has to match the directory the artifact ships under. It is not
+  # in versions.env — it comes from PW's browsers.json at build time — so read it
+  # off the base image, which already carries exactly one webkit-<rev>.
+  docker pull -q "$PROBE_BASE" >/dev/null
+  WK_REV="${WK_REV:-$(docker run --rm "$PROBE_BASE" \
+    sh -c 'ls -d /ms-playwright/webkit-* 2>/dev/null' | head -1 | grep -oE '[0-9]+$')}"
+  [ -n "$WK_REV" ] || { echo "no webkit-<rev> in $PROBE_BASE; set WK_REV=<rev>" >&2; exit 1; }
+  echo "webkit revision ${WK_REV} (from ${PROBE_BASE})"
+  build_context=$(mktemp -d)
+  trap 'rm -rf "$build_context"' EXIT
+  cat > "$build_context/Dockerfile" <<EOF
+FROM ${WK_PACKAGE}:${TARGET} AS artifact
+FROM ${PROBE_BASE}
+USER root
+RUN rm -rf /ms-playwright/webkit-${WK_REV}/minibrowser-wpe
+COPY --from=artifact /webkit/minibrowser-wpe /ms-playwright/webkit-${WK_REV}/minibrowser-wpe
+RUN chmod -R a+rX /ms-playwright/webkit-${WK_REV}/minibrowser-wpe \\
+ && chmod a+x /ms-playwright/webkit-${WK_REV}/minibrowser-wpe/MiniBrowser \\
+              /ms-playwright/webkit-${WK_REV}/minibrowser-wpe/WPE*Process
+USER runner
+WORKDIR ${WORKDIR}
+RUN npm init -y >/dev/null && npm i playwright-core@${PW_VERSION} >/dev/null 2>&1
+EOF
+  docker build -q -t "$IMAGE" "$build_context" >/dev/null
+fi
+
+echo "===== ${TARGET} — ${PROBE} ====="
+
+# Env is per-target and must NOT be shared. The sandbox escape hatch and the
+# GST_* paths below are Alpine-specific: /usr/lib/gstreamer-1.0 does not exist on
+# the official noble image (it uses /usr/lib/x86_64-linux-gnu/gstreamer-1.0), and
+# pointing GStreamer at an empty dir takes the browser down mid-probe — which
+# reads as "official crashes on ungranted capture" and is purely our own env.
+# The control runs bare, exactly as Playwright ships it.
+ARTIFACT_ENV=()
+if [ "$TARGET" != "official" ]; then
+  # apparmor/seccomp unconfined + SYS_ADMIN + NET_ADMIN are what WebKit's bwrap
+  # needs even with the escape hatch set; peeled by error, see
+  # project_webkit_smoke_sandbox_strip_layers.
+  ARTIFACT_ENV=(
+    -e WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+    -e WEBKIT_FORCE_SANDBOX=0
+    -e GST_PLUGIN_SYSTEM_PATH_1_0=/usr/lib/gstreamer-1.0
+    -e GST_PLUGIN_SCANNER_1_0=/usr/libexec/gstreamer-1.0/gst-plugin-scanner
+    -e GST_REGISTRY_1_0=/tmp/gst-registry.bin
+  )
+fi
+
+PASSTHROUGH_ENV=()
+for var in GST_DEBUG GST_DEBUG_FILE DEBUG; do
+  [ -n "${!var:-}" ] && PASSTHROUGH_ENV+=(-e "$var=${!var}")
+done
+
+docker run --rm -i \
+  --security-opt seccomp=unconfined \
+  --security-opt apparmor=unconfined \
+  --cap-add SYS_ADMIN --cap-add NET_ADMIN \
+  "${ARTIFACT_ENV[@]+"${ARTIFACT_ENV[@]}"}" \
+  "${PASSTHROUGH_ENV[@]+"${PASSTHROUGH_ENV[@]}"}" \
+  -v "$HERE/$PROBE:${WORKDIR}/$(basename "$PROBE"):ro" \
+  -w "$WORKDIR" \
+  "$IMAGE" node "$(basename "$PROBE")"


### PR DESCRIPTION
Promoting the probe that found the camera/mic root cause. It only existed in a scratch dir, and it replaced a ~4.5 h build round per hypothesis with about 30 seconds — that seemed worth more than the session that produced it.

## What it does

```
./run-capture-probe.sh official
./run-capture-probe.sh wk-gtk-sha-<sha>
```

Stages a producer artifact onto the consumer image and runs a probe against it, or runs Playwright's own image bare as the control. Official:

```
grant         query(camera/mic)  video+audio      video            audio
none          prompt/prompt      NotAllowedError  NotAllowedError  NotAllowedError
camera-only   granted/denied     NotAllowedError  video            NotAllowedError
camera+mic    granted/granted    audio+video      video            audio
```

An artifact that grants every row regardless of the query column is the blanket-grant failure (what `525f238` produced). One that denies every row has the mock devices off (pre-`ed83438`). The diagnosis is one screen.

## Why the environment is the whole feature

Three ways of getting it wrong each look like a browser bug rather than a harness bug, and I hit all three:

- `WEBKIT_DISABLE_SANDBOX=1` is a spelling WebKit silently ignores, so bwrap stays live and `enumerateDevices` **crashes the page**. That same typo already cost this repo the file-upload and download residuals once.
- Our Alpine `GST_*` paths don't exist on the official noble image. Pointing GStreamer at an empty dir takes the browser down mid-probe, which reads as "official crashes on ungranted capture" and is purely our own env. So the control runs bare and only artifacts get that block — I had this wrong first and the control "failed" convincingly.
- `navigator.mediaDevices` is undefined outside a secure context and `about:blank` doesn't qualify, so it serves over `http://localhost`.

`pw-conformance.yml` now carries a pointer back, so the two env blocks are changed together.

## Two design choices worth flagging

**It reports both `permissions.query` and `getUserMedia`.** They travel different paths through PW's patches, and the entire investigation turned on query agreeing with official on every row while getUserMedia did not. A getUserMedia-only probe blames the wrong layer.

**Fresh context per cell, not per row.** `grantPermissions` replaces the set for an origin, so a stale grant silently passes the next row; and repeated `getUserMedia` on one ungranted page takes the browser down — official dies on the third call. That crash is real and reproducible, I just didn't chase it.

## Retrocompat

Nothing wired into CI. `run-capture-probe.sh` is invoked by hand; the only workflow change is a two-line comment.

## Out of scope

- Making this a CI job. It's a diagnostic, and the conformance suite already gates the behaviour.
- The `PROBE_BASE` default is `alpine-dood-playwright:edge` — the only non-sha tag published for that package. If `edge` goes stale the probe measures a stale runtime; overridable via env, but I did not add a freshness assert.

## For you

- Both paths were run end to end before I committed, and the webkit revision is read off the base image because `versions.env` doesn't carry it (it comes from PW's `browsers.json` at build time).
- Does `playwright/alpine-browsers/webkit/probes/` sit where you'd want it, or would you rather diagnostics live in one top-level place across browsers? There are chromium and firefox equivalents I'd write the same way next time.
