### PR TITLE
fix(ci): retry the aports fetch, and report configure's hardening decision

### DIFF
--- a/playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh
@@ -21,14 +21,33 @@ mkdir -p "$OUT"
 API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
 LIST_URL="$API/repository/tree?path=community/chromium&ref=$REF&per_page=100"
 
-files=$(curl -fsSL "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
+# gitlab.alpinelinux.org drops connections: run 32892351327 lost a whole Firefox
+# round to `curl: (28) Failed to connect ... after 133306 ms`, and the aports
+# fetch was the only un-retried curl left in the build. Same 3-try shape as
+# firefox/scripts/fetch-pw-patches.sh — duplicated rather than shared because
+# each image COPYs only its own scripts/ dir. --connect-timeout so a dead socket
+# fails fast enough for the retries to fit inside the step.
+retry_curl() {
+  local n=1
+  while (( n <= 3 )); do
+    if curl -fsSL --connect-timeout 20 "$@"; then
+      return 0
+    fi
+    echo "  retry $n/3 (gitlab unreachable?) — sleep $((n*5))s" >&2
+    sleep $((n*5))
+    n=$((n+1))
+  done
+  return 1
+}
+
+files=$(retry_curl "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
 
 [[ -z "$files" ]] && { echo "fetch-aports: no files at ref=$REF (gitlab API empty)" >&2; exit 1; }
 
 for f in $files; do
   raw="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/chromium/$f"
   echo "  fetch $f"
-  curl -fsSL "$raw" -o "$OUT/$f"
+  retry_curl "$raw" -o "$OUT/$f"
 done
 
 echo "aports community/chromium fetched to $OUT ($(ls -1 "$OUT" | wc -l) files)"

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -574,6 +574,25 @@ mach_rc=0
 ./mach build || mach_rc=$?
 echo "===== END ./mach build (rc=$mach_rc) ====="
 
+# What did configure ACTUALLY decide about hardening? The perf/firefox-no-hardening
+# arm came back with a byte-identical .text, and nothing in the build log can
+# separate "the flag changed no codegen" from "the flag never reached the
+# compiler" — moz.configure turns hardening ON when the option is absent as well
+# as when it is passed, so deleting the line is a silent no-op. autoconf.mk is
+# what configure wrote, so it is the only cheap discriminator.
+#
+# MOZ_OPTIMIZE is the positive control: it must always print. If the whole block
+# comes back empty, the grep is broken, not the hardening.
+AUTOCONF_MK="$SRC/obj/config/autoconf.mk"
+if [[ -r "$AUTOCONF_MK" ]]; then
+  echo "===== configure flags (hardening + control) ====="
+  grep -E '^(MOZ_HARDENING|MOZ_TRIVIAL_AUTO_VAR_INIT|MOZ_OPTIMIZE|MOZ_LTO|MOZ_PGO)' \
+    "$AUTOCONF_MK" | sed 's/^/  /' || echo "  (no match — grep is broken, see control above)"
+  echo "===== end configure flags ====="
+else
+  echo "WARNING: no autoconf.mk at $AUTOCONF_MK — hardening flags unreportable" >&2
+fi
+
 # cbindgen 0.29.4 (Alpine edge) has a regression where impl-associated
 # constants used in Rust array-size expressions (e.g. `[BudgetType;
 # BudgetType::COUNT]`) get emitted as bare `[COUNT]` in the generated

--- a/playwright/alpine-browsers/firefox/scripts/fetch-aports.sh
+++ b/playwright/alpine-browsers/firefox/scripts/fetch-aports.sh
@@ -19,15 +19,34 @@ mkdir -p "$OUT"
 API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
 LIST_URL="$API/repository/tree?path=community/firefox&ref=$REF&per_page=100"
 
+# gitlab.alpinelinux.org drops connections: run 32892351327 lost a whole Firefox
+# round to `curl: (28) Failed to connect ... after 133306 ms`, and the aports
+# fetch was the only un-retried curl left in the build. Same 3-try shape as
+# firefox/scripts/fetch-pw-patches.sh — duplicated rather than shared because
+# each image COPYs only its own scripts/ dir. --connect-timeout so a dead socket
+# fails fast enough for the retries to fit inside the step.
+retry_curl() {
+  local n=1
+  while (( n <= 3 )); do
+    if curl -fsSL --connect-timeout 20 "$@"; then
+      return 0
+    fi
+    echo "  retry $n/3 (gitlab unreachable?) — sleep $((n*5))s" >&2
+    sleep $((n*5))
+    n=$((n+1))
+  done
+  return 1
+}
+
 # List then fetch each file. jq parses the GitLab API response.
-files=$(curl -fsSL "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
+files=$(retry_curl "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
 
 [[ -z "$files" ]] && { echo "fetch-aports: no files at ref=$REF (gitlab API returned nothing)" >&2; exit 1; }
 
 for f in $files; do
   raw="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/firefox/$f"
   echo "  fetch $f"
-  curl -fsSL "$raw" -o "$OUT/$f"
+  retry_curl "$raw" -o "$OUT/$f"
 done
 
 echo "aports community/firefox fetched to $OUT ($(ls -1 "$OUT" | wc -l) files)"


### PR DESCRIPTION
The push-to-main build for #111 ([32892351327](https://github.com/jclaveau/ci-prebuilds/actions/runs/32892351327)) died 4m40s in:

```
curl: (28) Failed to connect to gitlab.alpinelinux.org:443 after 133306 ms
```

Nothing was wrong with the symbol strip — its PR CI was green and the *push* build was not. The cost was a whole Firefox round plus `ff-latest` sitting at `d86baaa` for a day, so the strip merged but never shipped. I only noticed because I checked the tag's `org.opencontainers.image.revision` instead of trusting that a merged PR ships.

`fetch-pw-patches.sh` already had `retry_curl` for exactly this reason. The two `fetch-aports.sh` copies were the last single-shot curls on the FF and chromium paths, so they get the same three-try shape.

`--connect-timeout 20` is the part that actually matters here. The default let one dead socket burn 133 s; three of those would not have fit in the step, so the retry alone would have been decoration.

## Verified

Both paths, against the real endpoint — not just read back:

- firefox fetches 23 files, chromium 25 (success path unbroken)
- a bad ref retries `1/3`, `2/3`, `3/3` with 5/10/15 s backoff, then fails

## Cost, stated plainly

One cold FF prebuilt-base reseed. `fetch-aports.sh` lives inside the patch-set hash, which moves `20a2146d1388` → `bb8f5f5271fe`. That is the correct direction — the hash cannot distinguish "added a retry" from "changed what gets fetched", and #81 exists precisely because guessing that wrong ships an unpatched artifact. A one-off ~5 h reseed buys not losing a random ~5 h round to a network blip.

## Second commit: report what configure decided about hardening

Riding this PR rather than its own, because `fetch-aports.sh` already moves the patch-set hash — one cold reseed instead of two. Splitting by intent would cost ~5 h of runner time to say the same thing.

The `perf/firefox-no-hardening` arm is **void**: `--disable-hardening` reached configure and `.text` came back byte-identical at 118 846 320. That measurement cannot distinguish "hardening costs nothing" from "the flag never reached the compiler" — and `moz.configure` enables hardening when the option is *absent* as well as when it is passed, so deleting the line is a silent no-op and the obvious A/B does not exist.

`autoconf.mk` is what configure actually wrote, so `3ac6cde` prints it. `MOZ_OPTIMIZE` is in the grep as a positive control: it must always appear, so an empty block means the probe broke rather than hardening being off. Verified on three synthetic `autoconf.mk` files — present, absent, and missing-file.

The next FF build then returns an answer either way instead of another void arm.

## Out of scope

Three other un-retried curls exist — `fetch-chromium-src.sh`, `resolve-aports-ref.sh`, `fetch-pw-browsers-json.sh`. None of them has cost us a round yet, and widening the diff would drag more files into the patch-set hash. Happy to do them in a follow-up if you'd rather have it uniform.

## Question

`retry_curl` is now duplicated four times. Each image's build context `COPY`s only its own `scripts/` dir, so a shared file isn't reachable without restructuring the contexts — is that worth doing, or is four copies of nine lines fine?
