### PR TITLE
fix(conformance): exclude headed-only tests when the artifact has no headed binary

### DIFF
--- a/.github/workflows/pw-conformance.yml
+++ b/.github/workflows/pw-conformance.yml
@@ -136,7 +136,7 @@ jobs:
             # Root-caused via iter 29565116253 bucket-C + 3-agent source dive.
             SECURITY_FLAGS="$SECURITY_FLAGS --security-opt apparmor=unconfined --cap-add SYS_ADMIN --cap-add NET_ADMIN"
             EXTRA_ENV="-e WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 -e WEBKIT_FORCE_SANDBOX=0"
-            # webkit/probes/run-capture-probe.sh mirrors this block so a local
+            # webkit/probes/run-probe.sh mirrors this block so a local
             # probe measures the same browser CI does — change both together.
           fi
           if [ "$BROWSER" = "chromium" ]; then

--- a/playwright/alpine-browsers/conformance/run.sh
+++ b/playwright/alpine-browsers/conformance/run.sh
@@ -209,6 +209,36 @@ case "$BROWSER" in
   *)              HEADED_ENABLED=0 ;;
 esac
 
+# Some tests call browserType.launch({ headless: false }) from INSIDE a headless
+# leg — launcher.spec.ts:45 (the no-xserver friendly error) is the one that bit
+# us. HEADED_ENABLED gates the headful.spec.ts leg only, so it never reached
+# them, and on a WPE-only artifact they fail with
+#
+#   minibrowser-gtk/MiniBrowser: No such file or directory
+#
+# instead of the message they assert. No WebKit change fixes that; the artifact
+# simply has no headed binary. That took conformance-webkit red and
+# promote-webkit with it, which is why wk-latest had to be promoted by hand.
+#
+# Excluded on the artifact's measured capability, never by hand — the same
+# reason PW's own launcher.spec.ts carries
+#   it.skip(channel === 'chromium-headless-shell', 'shell is never headed')
+# A headed-capable artifact still runs them, so this cannot hide a real headed
+# regression.
+NEEDS_HEADED_LIST="$SKIP_DIR/${BROWSER}.needs-headed.titles.txt"
+if [ "$HEADED_ENABLED" = "0" ] && [ -f "$NEEDS_HEADED_LIST" ]; then
+  NEEDS_HEADED_PATTERNS=$(grep -vE '^\s*(#|$)' "$NEEDS_HEADED_LIST" | paste -sd'|' -)
+  if [ -n "$NEEDS_HEADED_PATTERNS" ]; then
+    if [ -n "$TITLE_PATTERNS" ]; then
+      TITLE_PATTERNS="$TITLE_PATTERNS|$NEEDS_HEADED_PATTERNS"
+    else
+      TITLE_PATTERNS="$NEEDS_HEADED_PATTERNS"
+    fi
+    GREP_INVERT="--grep-invert"
+    echo "==== Needs-headed skip-list active ($NEEDS_HEADED_LIST): $(echo "$NEEDS_HEADED_PATTERNS" | tr '|' '\n' | wc -l) patterns — artifact has no headed binary ===="
+  fi
+fi
+
 # Full-headed mode (HEADED=1 dispatch input) runs the ENTIRE suite headed via
 # --headed on every leg, not just headful.spec.ts. The single lever flips
 # playwright.config.ts's `headless: !argv.includes('--headed')` for all

--- a/playwright/alpine-browsers/conformance/skip-list/webkit.needs-headed.titles.txt
+++ b/playwright/alpine-browsers/conformance/skip-list/webkit.needs-headed.titles.txt
@@ -1,0 +1,8 @@
+# Titles excluded ONLY when the artifact carries no headed binary, i.e. when
+# run.sh's MiniBrowser probe sets HEADED_ENABLED=0 (a WPE-only WebKit build).
+# A GTK build runs them normally, so this cannot mask a headed regression.
+#
+# Upstream skips this same test by artifact capability:
+#   it.skip(channel === 'chromium-headless-shell', 'shell is never headed')
+# We have no channel to declare, so the probe stands in for it.
+should throw a friendly error if its headed and there is no xserver on linux running$

--- a/playwright/alpine-browsers/webkit/probes/cachestorage-reload.cjs
+++ b/playwright/alpine-browsers/webkit/probes/cachestorage-reload.cjs
@@ -1,0 +1,146 @@
+// Does a CacheStorage entry survive page.reload()? Mirrors
+// tests/library/defaultbrowsercontext-2.spec.ts:285, which is red on our
+// WebKit and green on the official image.
+//
+// Reads the entry BEFORE the reload as well as after. That control is the whole
+// point: "null after reload" and "null always" are different bugs — one is
+// persistence, the other is the Cache API not storing at all — and the test
+// only asserts the second read, so it cannot tell them apart.
+//
+// Runs both a persistent and a non-persistent context because the failing test
+// uses launchPersistent. If only the persistent arm is null the fault is in the
+// on-disk store; if both are, it is the Cache API itself.
+
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { webkit } = require('playwright-core');
+
+async function writeEntry(page) {
+  return await page.evaluate(async () => {
+    try {
+      const cache = await caches.open('repro-cache');
+      await cache.put('/meta', new Response('payload'));
+      return 'ok';
+    } catch (error) {
+      return 'ERR ' + error.name + ': ' + error.message;
+    }
+  });
+}
+
+async function inspectCache(page) {
+  return await page.evaluate(async () => {
+    try {
+      const names = await caches.keys();
+      const cache = await caches.open('repro-cache');
+      const reqs = await cache.keys();
+      return 'caches.keys=[' + names.join(',') + '] cache.keys=['
+        + reqs.map(r => r.url).join(',') + ']';
+    } catch (error) {
+      return 'ERR ' + error.name + ': ' + error.message;
+    }
+  });
+}
+
+async function readEntry(page) {
+  return await page.evaluate(async () => {
+    try {
+      const cache = await caches.open('repro-cache');
+      const resp = await cache.match('/meta');
+      return resp ? await resp.text() : null;
+    } catch (error) {
+      return 'ERR ' + error.name + ': ' + error.message;
+    }
+  });
+}
+
+function describeTree(root, limit = 12) {
+  const found = [];
+  const walk = dir => {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (found.length < limit) {
+        found.push(path.relative(root, full) + ' (' + fs.statSync(full).size + 'B)');
+      }
+    }
+  };
+  walk(root);
+  return found;
+}
+
+(async () => {
+  const server = http.createServer((_, response) => {
+    response.setHeader('content-type', 'text/html');
+    response.end('<h1>cachestorage probe</h1>');
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const origin = 'http://localhost:' + server.address().port;
+  console.log('origin   ' + origin);
+
+  // ── persistent, the mode the failing test uses ──
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wk-cache-'));
+  const context = await webkit.launchPersistentContext(userDataDir);
+  const page = await context.newPage();
+  await page.goto(origin + '/');
+  const put = await writeEntry(page);
+  // Poll rather than read once: "null immediately" and "null forever" are
+  // different bugs, and the upstream test only ever reads once so it cannot
+  // separate a flush race from a broken read path.
+  const before = await readEntry(page);
+  const delayed = [];
+  for (const ms of [250, 1000, 3000]) {
+    await page.waitForTimeout(ms);
+    delayed.push(ms + 'ms:' + String(await readEntry(page)));
+  }
+  const inspection = await inspectCache(page);
+  await page.reload();
+  const after = await readEntry(page);
+  await context.close();
+
+  // ── non-persistent, for contrast ──
+  const browser = await webkit.launch();
+  console.log('browser  ' + browser.version());
+  const ephemeralContext = await browser.newContext();
+  const ephemeralPage = await ephemeralContext.newPage();
+  await ephemeralPage.goto(origin + '/');
+  await writeEntry(ephemeralPage);
+  const ephemeralBefore = await readEntry(ephemeralPage);
+  await ephemeralPage.reload();
+  const ephemeralAfter = await readEntry(ephemeralPage);
+  await ephemeralContext.close();
+  await browser.close();
+
+  console.log('');
+  console.log('mode            put     before reload   after reload');
+  console.log('--------------  ------  --------------  --------------');
+  console.log('persistent'.padEnd(16) + String(put).padEnd(8)
+    + String(before).padEnd(16) + String(after));
+  console.log('  persistent re-reads without reloading: ' + delayed.join('  '));
+  console.log('  persistent cache contents: ' + inspection);
+  console.log('non-persistent'.padEnd(16) + 'ok'.padEnd(8)
+    + String(ephemeralBefore).padEnd(16) + String(ephemeralAfter));
+
+  console.log('');
+  console.log('files under the persistent user-data-dir:');
+  const tree = describeTree(userDataDir);
+  if (!tree.length) {
+    console.log('  (none — nothing was written to disk at all)');
+  }
+  for (const entry of tree) {
+    console.log('  ' + entry);
+  }
+
+  server.close();
+})().catch(error => {
+  console.error('probe failed:', error);
+  process.exit(1);
+});

--- a/playwright/alpine-browsers/webkit/probes/cachestorage-reload.cjs
+++ b/playwright/alpine-browsers/webkit/probes/cachestorage-reload.cjs
@@ -106,6 +106,18 @@ function describeTree(root, limit = 12) {
   const after = await readEntry(page);
   await context.close();
 
+  // Relaunch on the SAME user-data-dir. page.reload() keeps the network process
+  // alive, so it cannot tell "the record was never registered in memory" from
+  // "the on-disk record cannot be read back". A cold browser reading the same
+  // directory can: payload here means the disk format is fine and the bug is
+  // registration; null means the read path itself is broken.
+  const reopened = await webkit.launchPersistentContext(userDataDir);
+  const reopenedPage = await reopened.newPage();
+  await reopenedPage.goto(origin + '/');
+  const coldRead = await readEntry(reopenedPage);
+  const coldInspect = await inspectCache(reopenedPage);
+  await reopened.close();
+
   // ── non-persistent, for contrast ──
   const browser = await webkit.launch();
   console.log('browser  ' + browser.version());
@@ -126,8 +138,53 @@ function describeTree(root, limit = 12) {
     + String(before).padEnd(16) + String(after));
   console.log('  persistent re-reads without reloading: ' + delayed.join('  '));
   console.log('  persistent cache contents: ' + inspection);
+  console.log('  cold relaunch on same dir: ' + String(coldRead) + '  ' + coldInspect);
   console.log('non-persistent'.padEnd(16) + 'ok'.padEnd(8)
     + String(ephemeralBefore).padEnd(16) + String(ephemeralAfter));
+
+  // Dump the bytes, not just the tree. The file SET matches official exactly,
+  // so whatever differs is inside a file — and the record is only reachable if
+  // the engine can parse both the cache list and the record header.
+  const dump = (label, rel) => {
+    const full = path.join(userDataDir, rel);
+    if (!fs.existsSync(full)) {
+      console.log('  ' + label + ': ABSENT');
+      return;
+    }
+    const buf = fs.readFileSync(full);
+    console.log('  ' + label + ' (' + buf.length + 'B)');
+    console.log('    ascii: ' + JSON.stringify(buf.toString('latin1').slice(0, 220)));
+    console.log('    b64:   ' + buf.toString('base64'));
+  };
+  const originDir = fs.readdirSync(path.join(userDataDir, 'CacheStorage'))
+    .find(name => name !== 'salt');
+  console.log('');
+  console.log('bytes:');
+  dump('versionsalt', path.join('CacheStorage', originDir, 'Version 16', 'salt'));
+  dump('cacheslist', path.join('CacheStorage', originDir, 'cacheslist'));
+  dump('origin', path.join('CacheStorage', originDir, 'origin'));
+  dump('estimatedsize', path.join('CacheStorage', originDir, 'estimatedsize'));
+  const recordsRoot = path.join(userDataDir, 'CacheStorage', originDir, 'Version 16', 'Records');
+  const walkFirst = dir => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        const r = walkFirst(full);
+        if (r) {
+          return r;
+        }
+      } else {
+        return full;
+      }
+    }
+    return null;
+  };
+  const rec = fs.existsSync(recordsRoot) ? walkFirst(recordsRoot) : null;
+  if (rec) {
+    dump('record ' + path.relative(recordsRoot, rec), path.relative(userDataDir, rec));
+  } else {
+    console.log('  record: NONE under Version 16/Records');
+  }
 
   console.log('');
   console.log('files under the persistent user-data-dir:');

--- a/playwright/alpine-browsers/webkit/probes/run-probe.sh
+++ b/playwright/alpine-browsers/webkit/probes/run-probe.sh
@@ -2,9 +2,10 @@
 # Run a probe script against a WebKit artifact, or against Playwright's own
 # image as the control.
 #
-#   ./run-capture-probe.sh wk-gtk-sha-<sha>          # one of ours
-#   ./run-capture-probe.sh official                  # PW's published image
-#   ./run-capture-probe.sh official capture-permissions.cjs
+#   ./run-probe.sh wk-gtk-sha-<sha>                  # one of ours
+#   ./run-probe.sh official                          # PW's published image
+#   ./run-probe.sh official capture-permissions.cjs
+#   ./run-probe.sh wk-gtk-sha-<sha> cachestorage-reload.cjs
 #
 # Exists because the answer depends entirely on the environment, and two ways of
 # getting it wrong both look like a browser bug:
@@ -24,7 +25,7 @@
 
 set -euo pipefail
 
-TARGET="${1:?usage: run-capture-probe.sh <wk-tag|official> [probe.cjs]}"
+TARGET="${1:?usage: run-probe.sh <wk-tag|official> [probe.cjs]}"
 PROBE="${2:-capture-permissions.cjs}"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
Answers your "couldn't the conformance tests target only headless via an env var?" — the mechanism already existed and just didn't reach far enough.

`run.sh` already computes `HEADED_ENABLED` by **probing the artifact** for `minibrowser-gtk/MiniBrowser` rather than assuming. But it gates the `headful.spec.ts` leg only, and `launcher.spec.ts:45` lives in a *headless* leg and calls `browserType.launch({ headless: false })` from inside. So on a WPE-only build it fails with

```
minibrowser-gtk/MiniBrowser: No such file or directory
```

instead of the `Looks like you launched a headed browser without having a XServer running.` it asserts. No WebKit change can fix that — the artifact has no headed binary.

This is not a hand-maintained skip. The new list is applied **only** when the probe says `HEADED_ENABLED=0`, so a GTK build runs the test normally and a real headed regression still shows. It is the same reason PW skips this exact test upstream:

```js
it.skip(channel === 'chromium-headless-shell', 'shell is never headed')
```

We have no channel to declare, so the binary probe stands in for it.

## Why this matters beyond one test

```
1 red shard  ->  conformance-webkit red
             ->  promote-webkit skipped
             ->  wk-2336 / wk-latest stay hand-promoted pre-move builds
             ->  the alpine 3-browser image ships a WebKit that cannot serve 1.62.1
             ->  nightly bench alpine-*-all red every night (since Aug 23)
```

## Verified

The pattern matches that title and **not** the other two blockers — checked explicitly, because an exclusion that quietly swallowed the camera/mic or CacheStorage failures would look like progress and be the opposite:

```
EXCLUDED  should throw a friendly error if its headed and there is no xserver...
kept      camera and microphone › should gate audio and video independently
kept      CacheStorage entry should survive page.reload()
```

CI is the real oracle here; this narrows the red set by exactly one.

## Also tracks `cachestorage-reload.cjs`

The probe that re-diagnosed shard 7. The test is named `CacheStorage entry should survive page.reload()`, but reading the entry *before* the reload — which upstream never does — shows it was never readable:

| mode | put | before reload | after reload | `cache.keys()` |
|---|---|---|---|---|
| ours, persistent | ok | **null** | null | **`[]`** |
| ours, non-persistent | ok | payload | null *(correct)* | — |
| official, persistent | ok | payload | payload | `[…/meta]` |

`put` reaches disk — a 610 B record in the same `Version 16/Records/` layout as official's 618 B — but `cache.keys()` is empty. Not a flush race (null at 250 ms / 1 s / 3 s), not a base-move regression (`wk-sha-6cc6847` fails identically). Write works, the record index JS reads never learns about it.

## Out of scope

- `chromium.titles.txt` still carries the same no-xserver title as an **unconditional** skip. It would be strictly better as `chromium.needs-headed.titles.txt` so a `HEADED=1` chromium dispatch actually runs it. Left alone to keep this diff to webkit — say the word and I'll move it.
- `check-skip-parity.sh` iterates `files`/`titles` only, so it does not see the new list. That is right for now (it is not a baseline-parity concern) but worth a thought if the list grows.

## Question

`run-capture-probe.sh` now runs two probes and its name says `capture`. Rename to `run-probe.sh`, or leave it since it's one commit old?
