### PR TITLE
fix(ci): make the runtime parity gate actually gate

### DIFF
--- a/.github/workflows/playwright-alpine-browsers.yml
+++ b/.github/workflows/playwright-alpine-browsers.yml
@@ -869,6 +869,9 @@ jobs:
               pw-conformance-*)        cp -r "$d" /tmp/alp/ ;;
             esac
           done
+          # Without pipefail the step takes tee's status and a "✗ FAIL" verdict
+          # concludes green — run 32941298683 did exactly that.
+          set -o pipefail
           ./scripts/check-runtime-parity.sh /tmp/alp /tmp/ubu | tee -a "$GITHUB_STEP_SUMMARY"
 
   # ────────────────────────────────────────────────────────────────────

--- a/.github/workflows/tests-conformance.yml
+++ b/.github/workflows/tests-conformance.yml
@@ -1,0 +1,29 @@
+name: tests-conformance
+
+# Unit tests for the conformance gates in scripts/. They decide whether a
+# producer run is allowed to call itself same-or-better, so a gate that reads
+# its inputs wrong ships a false green — which is exactly what happened in run
+# 32941298683. Runs in seconds; no images, no browsers.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/check-runtime-parity.sh'
+      - 'tests/conformance/**'
+      - '.github/workflows/tests-conformance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-runtime-parity.sh'
+      - 'tests/conformance/**'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: runtime parity gate unit test
+        run: bash tests/conformance/test-check-runtime-parity.sh

--- a/scripts/check-runtime-parity.sh
+++ b/scripts/check-runtime-parity.sh
@@ -13,8 +13,16 @@
 #
 # Rules:
 #   - Sum passes per browser on each side.
-#   - FAIL if Alpine < Ubuntu on any browser.
+#   - FAIL if Alpine < Ubuntu on any browser that RAN on both sides.
+#   - A browser with no shards on a side did not run — the producer builds
+#     per-browser and the Ubuntu control leg runs on its own schedule, so a
+#     firefox-only dispatch would otherwise read as "chromium regressed by
+#     5950" and, once the exit code is honoured, red every such run.
 #   - Otherwise print the markdown tally and exit 0.
+#
+# The caller must not swallow the exit code. `script | tee -a $GITHUB_STEP_SUMMARY`
+# takes tee's status unless the step sets `pipefail`, which is how run
+# 32941298683 printed "✗ FAIL" and concluded green.
 #
 # Usage: check-runtime-parity.sh <alpine_dir> <ubuntu_dir>
 
@@ -24,6 +32,15 @@ ALPINE_DIR="${1:?usage: check-runtime-parity.sh <alpine_dir> <ubuntu_dir>}"
 UBUNTU_DIR="${2:?usage: check-runtime-parity.sh <alpine_dir> <ubuntu_dir>}"
 
 BROWSERS=(chromium firefox webkit)
+
+# Presence, not pass count: a browser that ran and passed nothing is a
+# regression, a browser that never ran is not comparable at all.
+has_shards() {
+  local dir="$1" browser="$2"
+  find "$dir" -name stats.txt -print0 2>/dev/null | \
+    xargs -0 -r cat 2>/dev/null | \
+    grep -q "browser=$browser "
+}
 
 sum_field() {
   local dir="$1" browser="$2" field="$3"
@@ -57,13 +74,19 @@ for b in "${BROWSERS[@]}"; do
   u_fail=$(sum_field "$UBUNTU_DIR" "$b" failed)
   u_skip=$(sum_field "$UBUNTU_DIR" "$b" skipped)
   delta=$((a_pass - u_pass))
-  status="✓"
-  if [ "$u_pass" -gt 0 ] && [ "$a_pass" -lt "$u_pass" ]; then
+  a_ran=0; has_shards "$ALPINE_DIR" "$b" && a_ran=1
+  u_ran=0; has_shards "$UBUNTU_DIR" "$b" && u_ran=1
+  if [ "$a_ran" = 0 ] && [ "$u_ran" = 0 ]; then
+    status="— (neither side ran)"
+  elif [ "$a_ran" = 0 ]; then
+    status="— (not built this run)"
+  elif [ "$u_ran" = 0 ]; then
+    status="— (no Ubuntu baseline)"
+  elif [ "$a_pass" -lt "$u_pass" ]; then
     status="✗ **FAIL**"
     rc=1
-  elif [ "$u_pass" -eq 0 ] && [ "$a_pass" -eq 0 ]; then
-    # Both sides absent — treat as "no data", not pass.
-    status="— (no data)"
+  else
+    status="✓"
   fi
   printf "| %s | %s / %s / %s | %s / %s / %s | %+d | %s |\n" \
     "$b" "$a_pass" "$a_fail" "$a_skip" "$u_pass" "$u_fail" "$u_skip" "$delta" "$status"

--- a/tests/conformance/test-check-runtime-parity.sh
+++ b/tests/conformance/test-check-runtime-parity.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Unit test for the Alpine-vs-Ubuntu runtime parity gate.
+#
+# Exists because the gate was inert twice over: the workflow step piped it
+# into `tee` without `pipefail` so its exit code never reached CI, and it
+# read "this browser was not built in this run" as "this browser regressed
+# by every test Ubuntu passes". Run 32941298683 printed `✗ FAIL` for
+# chromium and concluded success. Both halves are asserted here — including
+# that a real regression still fails, so the fix for the second cannot
+# silently neutralise the first.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+GATE="$ROOT/scripts/check-runtime-parity.sh"
+
+failures=0
+checks=0
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+# One shard's worth of stats.txt, in the format conformance/run.sh writes.
+seed() {
+  local dir="$1" browser="$2" passed="$3"
+  mkdir -p "$dir/report-$browser-1"
+  printf 'browser=%s shard=1 suite=library passed=%s failed=0 skipped=0\n' \
+    "$browser" "$passed" > "$dir/report-$browser-1/stats.txt"
+}
+
+# $1 label, $2 expected rc, $3 expected status substring, rest: seed specs
+# as `side:browser:passed` where side is alp or ubu.
+expect() {
+  local label="$1" want_rc="$2" want_text="$3"; shift 3
+  local case_dir="$workdir/$checks"
+  mkdir -p "$case_dir/alp" "$case_dir/ubu"
+  local spec side browser passed
+  for spec in "$@"; do
+    IFS=: read -r side browser passed <<< "$spec"
+    seed "$case_dir/$side" "$browser" "$passed"
+  done
+
+  local out got=0
+  out=$("$GATE" "$case_dir/alp" "$case_dir/ubu" 2>&1) || got=$?
+  checks=$((checks + 1))
+  if [ "$got" != "$want_rc" ]; then
+    echo "FAIL: $label — exit $got, wanted $want_rc" >&2
+    echo "$out" | sed 's/^/    /' >&2
+    failures=$((failures + 1))
+    return
+  fi
+  if ! printf '%s' "$out" | grep -qF "$want_text"; then
+    echo "FAIL: $label — output does not contain '$want_text'" >&2
+    echo "$out" | sed 's/^/    /' >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# The case that shipped green: chromium has a Ubuntu baseline and was not
+# built on the Alpine side. Not comparable, so not a failure.
+expect "browser absent from the Alpine side" 0 "not built this run" \
+  ubu:chromium:5950 alp:firefox:5758 ubu:firefox:5000
+
+# The gate's actual subject — fewer Alpine passes than Ubuntu on a browser
+# both sides ran.
+expect "genuine regression still fails" 1 "FAIL" \
+  alp:firefox:4000 ubu:firefox:5000
+
+# Ran and passed nothing is a regression, not "absent": the shard file
+# exists, so the browser was exercised.
+expect "zero passes with shards present is a regression" 1 "FAIL" \
+  alp:firefox:0 ubu:firefox:5000
+
+expect "equal counts pass" 0 "| firefox |" \
+  alp:firefox:5000 ubu:firefox:5000
+
+expect "more Alpine passes pass" 0 "| firefox |" \
+  alp:firefox:5758 ubu:firefox:5000
+
+expect "no Ubuntu baseline is not a verdict" 0 "no Ubuntu baseline" \
+  alp:webkit:100
+
+echo "check-runtime-parity: $((checks - failures))/$checks checks passed"
+[ "$failures" -eq 0 ]


### PR DESCRIPTION
Reading the firefox producer run that just landed, I noticed its runtime parity
step printed

```
| chromium | 0 / 0 / 0 | 5950 / 0 / 116 | -5950 | ✗ **FAIL** |
### ✗ Alpine regressed vs Ubuntu
```

and the job concluded **success**. So this gate has never gated anything, and I
would rather find that out now than the first time it has something real to say.

Two independent reasons, and fixing either alone is wrong:

- **The exit code is discarded.** The step is
  `./scripts/check-runtime-parity.sh … | tee -a "$GITHUB_STEP_SUMMARY"`, and
  without `pipefail` bash takes tee's status. The script's `exit "$rc"` never
  reaches CI.
- **The comparison is vacuous.** The producer builds one browser per dispatch
  while the Ubuntu control leg runs on its own schedule, so a firefox-only run
  compares chromium's absent 0 against Ubuntu's 5950 and calls it a regression.

Turning on `pipefail` alone would have redded every per-browser dispatch from
here on. So the gate now compares a browser only when *both* sides actually ran,
which means distinguishing "no shards at all" from "shards that passed nothing"
— the second is still a regression and still fails.

While writing the presence check I found a third one: `xargs -r grep -l` exits 0
on an **empty** file list, so an absent side read as present. The unit test
caught it, which is the only reason it is not in this PR as a fourth bug.

## Verification

`tests/conformance/test-check-runtime-parity.sh`, wired into a new
`tests-conformance` workflow, covers six cases. Mutation-tested — each half of
the fix reverted on its own turns it red:

| reverted | result |
|---|---|
| the both-sides-ran rule | 4/6 (the absent-browser case fails *and* takes the baseline case with it) |
| the `xargs -r` fix | 5/6 |
| nothing | 6/6 |

## Open questions

- Should a browser with an Alpine side and **no** Ubuntu baseline be a failure
  rather than the `— (no Ubuntu baseline)` I gave it? It is currently how webkit
  reports, and I read it as "nothing to compare against" rather than "we lost
  the control" — but the opposite reading is defensible and it is your gate.
- `conformance-runtime-parity` runs per producer run, so once this merges the
  first genuine `Δ passed < 0` will red a producer run that used to go green.
  That is the point, but it is a behaviour change worth knowing about.

## Out of scope

- The static counterpart, `skip-list-parity`, which I have not audited for the
  same pipe-swallowing shape. Worth a grep across the workflows for
  `\.sh .* | tee` generally.
