### PR TITLE
docs(bench): the alpine images are not chromium-only any more

### DIFF
--- a/.github/workflows/benchmark-playwright.yml
+++ b/.github/workflows/benchmark-playwright.yml
@@ -240,7 +240,7 @@ jobs:
   # Same benchmark, but executed through nektos/act (the "use these images as your local act runner"
   # path). act runs inside this hosted job and drives the host Docker, so time-to-tests can't come from
   # the jobs API — the inner workflow prints a timestamp right before the tests and we measure from the
-  # `act` invocation, writing the result to an artifact the summary picks up. Chromium-only, 3 runs each.
+  # `act` invocation, writing the result to an artifact the summary picks up. 3 runs each.
   act:
     name: bench-act-${{ matrix.scenario }}-${{ matrix.browsers }}-${{ matrix.run }}
     needs: config
@@ -832,7 +832,9 @@ jobs:
               "The `…-playwright-gyp` rows are the same image **plus the node-gyp toolchain** "
               "(build-essential / build-base); compare each slim row with its `-gyp` twin to read the "
               "compiler's pull cost. "
-              "`alpine-dood-playwright` and `alpine-dind-playwright` are Chromium-only (no Firefox/WebKit on musl). The **act** tables run each "
+              "`alpine-dood-playwright` and `alpine-dind-playwright` carry all three browsers "
+              "(chromium, firefox and webkit, all built from source against musl), so the "
+              "*All browsers* tables measure the same work on every row. The **act** tables run each "
               "image as a local `nektos/act` runner, self-measured from `act` start; their *Image pull* "
               "also includes act's own start-up overhead, so it isn't directly comparable to the hosted "
               "`Initialize containers` time. The **warm** Δ columns exclude the pull (= install only) — "

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Image names follow `<os>-<mode>[-<layer>][-sudoer]`. Pick one of each axis:
 | **Layer** | none · `-node` · `-pnpm` · `-pnpm-gyp` · `-playwright` · `-playwright-gyp` | your needs |
 | **Flavor** | default (no runtime sudo) · `-sudoer` | hardened |
 
-- **One exception**: Playwright on Alpine is **Chromium-only** for now (using a --shell-only Chromium).
+- Playwright on Alpine carries **all three browsers** — chromium, firefox and webkit, built from source against musl rather than taken from the system packages.
 
 | Image | What it adds | Docs |
 | --- | --- | --- |

--- a/alpine-gha-tools/README.md
+++ b/alpine-gha-tools/README.md
@@ -49,7 +49,8 @@ your job if you lint shell.
   layers, so each stays independently versioned.
 - **musl, not glibc.** A handful of apt-only packages (`lsb-release`, `software-properties-common`,
   `locales`, `time`) have no Alpine counterpart and are dropped; some downstream layers diverge more
-  (notably Playwright, which on Alpine is Chromium-only via the system package).
+  (notably Playwright, whose three browsers are built from source against musl rather than
+  taken from the system packages).
 - In **GitHub Actions container jobs the steps run as root** (uid 0), ignoring the image's `USER runner`.
   The baked accounts/env/aliases matter for `docker run` / `act`, not inside a GHA job.
 - Published; tagged `latest` and a version-pinned `alpineXX.YY` (e.g. `alpine3.21`) on each push to main.


### PR DESCRIPTION
The bench summary prints, immediately under the *All browsers* tables where
`alpine-dood-playwright` and `alpine-dind-playwright` just scored 5/5 with an
11s test run against the official container's 10s:

> `alpine-dood-playwright` and `alpine-dind-playwright` are Chromium-only (no
> Firefox/WebKit on musl).

That stopped being true when firefox and webkit started shipping in those
images. Run 33030702952 is the first bench where all three browsers actually
launch on musl, so the note now contradicts the numbers directly above it — and
it is the kind of line someone quotes rather than re-derives.

The `act` job comment carried the same claim, so both are fixed.

The sweep found two more, in the places a user reads before any of this: the
top-level README listed it as the "one exception" to the image matrix, and
`alpine-gha-tools/README.md` cited it as a way downstream layers diverge on
musl. Both are in the second commit.

The remaining `chromium-only` hits are the bench's own table titles, which name
the chromium-only *scenario* rather than a limitation, so they stay.
