### PR TITLE
fix(ci): fail the perf probe when an arm is missing

### DIFF
--- a/.github/workflows/perf-probe.yml
+++ b/.github/workflows/perf-probe.yml
@@ -19,8 +19,8 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'Our image to measure (tag or full ref)'
-        default: 'ghcr.io/jclaveau/alpine-dood-playwright:latest'
+        description: 'Our image to measure. Docker Hub carries `latest`/`main`/`main-<sha>`; GHCR carries `sha-<full-40-char-sha>` and `edge` but NO `latest`.'
+        default: 'jclaveau/alpine-dood-playwright:latest'
         type: string
       browsers:
         description: 'CSV: chromium,firefox,webkit'
@@ -143,7 +143,7 @@ jobs:
           retention-days: 30
 
   report:
-    needs: probe
+    needs: [matrix, probe]
     if: '!cancelled()'
     runs-on: ubuntu-latest
     steps:
@@ -155,7 +155,36 @@ jobs:
           path: perf-current
           merge-multiple: true
 
+      # A missing arm must be LOUD. The first smoke run of this workflow pointed
+      # at a tag that did not exist, every alpine probe died on `manifest
+      # unknown`, and this job still went green rendering an official-only
+      # table — the same blindness that hid webkit for weeks, reproduced by the
+      # workflow built to end it. An absent arm cannot look like a measured one.
+      - name: Assert both arms reported
+        env:
+          BROWSERS: ${{ needs.matrix.outputs.browsers }}
+          RUNS: ${{ inputs.runs }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for browser in $(jq -r '.[]' <<< "$BROWSERS"); do
+            for arm in alpine official; do
+              got=$(find perf-current -name "$arm-$browser-run*.json" | wc -l)
+              if [ "$got" -ne "$RUNS" ]; then
+                echo "::error::$arm/$browser produced $got of $RUNS runs"
+                missing=1
+              else
+                echo "ok: $arm/$browser $got/$RUNS"
+              fi
+            done
+          done
+          exit "$missing"
+
       - name: Render
+        # Runs even when the assert failed: a partial table is still worth
+        # reading, as long as the job is already red and nobody mistakes it
+        # for a complete one.
+        if: '!cancelled()'
         env:
           OURS: ${{ inputs.image }}
           RUNS: ${{ inputs.runs }}


### PR DESCRIPTION
The first smoke run of this workflow pointed at
`ghcr.io/jclaveau/alpine-dood-playwright:latest`, which does not exist.
The two registries carry different tag namespaces: Docker Hub has
`latest`, `main` and `main-<sha>`; GHCR has `sha-<full-sha>` and `edge`
and no `latest` at all. Every alpine probe died on `manifest unknown`.

The part worth fixing is what happened next: the report job went GREEN and
rendered an official-only table. That is precisely the blindness this
workflow was built to end — webkit was unmeasured for weeks behind an
official-only table nobody read as broken — and the new workflow
reproduced it on its first run. An absent arm must not look like a
measured one.

So the report now asserts, per browser, that both arms produced exactly
`runs` files, and fails naming what is short. Render still runs on the
failed path, because a partial table is worth reading once the job is
already red; what it must never be is silently mistaken for a complete
one. Verified both ways: red on a 1-of-2 arm, green on a complete set.

Assisted-by: Claude:claude-opus-5[1m]

## Out of scope

- `node/Dockerfile`'s `ARG NODE_VERSION=22.23.2`. Renovate has the Node pin split across two groups and only one moved: #104 took setup-node to v24 in two workflows, while the customManager keeps offering 22.x patches for the image. Our runners and official PW run 24.18.1, the published ubuntu image runs 22.23.2, and that is ~14 points of `eval_rtt` on the probe's null arm. Bumping a published image's Node major is your call, not a side effect of a perf fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118sTwxy1ZMg1CKM3NFDgKi