### PR TITLE
perf(webkit): preload mimalloc past bmalloc's reach

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -99,7 +99,8 @@ RUN sudo touch /ms-playwright/firefox-${FF_REV}/INSTALLATION_COMPLETE \
 #    allocate nothing, stay identical (runs 32833439914, 32833725968).
 #    Scoped to the shim rather than ENV so it reaches firefox and its
 #    children and not the Node.js driving them, and so chromium's
-#    PartitionAlloc and webkit's bmalloc are left alone.
+#    PartitionAlloc is left alone. WebKit gets the same preload from its
+#    own pw_run.sh wrapper below — bmalloc covers only fastMalloc there.
 RUN sudo mv /ms-playwright/firefox-${FF_REV}/firefox/firefox \
             /ms-playwright/firefox-${FF_REV}/firefox/firefox.real \
  && printf '%s\n' \
@@ -126,6 +127,33 @@ COPY --from=wk-source /webkit/minibrowser-wpe /ms-playwright/webkit-${WK_REV}/mi
 COPY --from=wk-source /webkit/pw_run.sh /ms-playwright/webkit-${WK_REV}/pw_run.sh
 RUN sudo touch /ms-playwright/webkit-${WK_REV}/INSTALLATION_COMPLETE \
  && sudo chmod 755 /ms-playwright/webkit-${WK_REV}
+
+# The allocator, same lever as firefox's above. bmalloc/libpas is compiled in
+# (`USE_SYSTEM_MALLOC_DEFAULT OFF` for x86_64, no libc condition) but it backs
+# `WTF::fastMalloc` only — WebCore and JSC. Every other allocation in the
+# process goes to musl's mallocng: GLib/GObject, GStreamer, Skia, Cairo,
+# HarfBuzz, ICU, libsoup, fontconfig, freetype. That is the startup and
+# page-setup half of the process, and it is exactly the half measured slow
+# (goto_cold 1.52x, launch 1.37x, click_force 1.30x, context_page 1.26x
+# against official, while layout 0.95x and int_math 0.97x — engine code, the
+# part bmalloc already covers — is faster). `malloc` reads undefined in BOTH
+# libWPEWebKit and official's, so firefox's `nm -D` discriminator says nothing
+# here; the tell is which allocator answers the NON-fastMalloc calls.
+#
+# Wrapping pw_run.sh rather than exporting ENV keeps the preload off the Node
+# driver and off chromium, and rather than editing pw_run.sh's text so that a
+# PW-side rewrite of that script cannot silently drop it. pw_run.sh resolves
+# everything from `$(dirname "$0")`, so it is indifferent to being renamed
+# inside its own directory.
+RUN sudo mv /ms-playwright/webkit-${WK_REV}/pw_run.sh \
+            /ms-playwright/webkit-${WK_REV}/pw_run.real.sh \
+ && printf '%s\n' \
+        '#!/bin/sh' \
+        'DIR="$(dirname "$0")"' \
+        'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \
+        'exec "$DIR/pw_run.real.sh" "$@"' \
+  | sudo tee /ms-playwright/webkit-${WK_REV}/pw_run.sh >/dev/null \
+ && sudo chmod +x /ms-playwright/webkit-${WK_REV}/pw_run.sh
 
 # WebKit's bundle carries Mesa's software-GL closure (libgallium → libLLVM +
 # EGL/GL/gbm/drm/X11/xcb, ~225 MB on-disk) copied in by the producer's

--- a/playwright/alpine-browsers/conformance/build-runner.sh
+++ b/playwright/alpine-browsers/conformance/build-runner.sh
@@ -421,6 +421,21 @@ COPY strip-bundled-libs.sh /tmp/strip-bundled-libs.sh
 RUN bash /tmp/strip-mesa-closure.sh /ms-playwright/webkit-${ARTIFACT_REV}/minibrowser-wpe \\
  && bash /tmp/strip-bundled-libs.sh /ms-playwright/webkit-${ARTIFACT_REV}/minibrowser-wpe webkit \\
  && touch /ms-playwright/webkit-${ARTIFACT_REV}/INSTALLATION_COMPLETE
+# Allocator parity with playwright/Dockerfile.alpine's pw_run.sh wrapper, for
+# the same reason as firefox's above: bmalloc backs fastMalloc only, so GLib,
+# GStreamer, Skia, Cairo, HarfBuzz, ICU, libsoup and fontconfig all allocate
+# through musl's mallocng, and conformance has to exercise the allocator we
+# actually ship. pw_run.sh resolves everything from \$(dirname "\$0"), so it
+# does not care that it was renamed inside its own directory.
+RUN WKRUN=/ms-playwright/webkit-${ARTIFACT_REV}/pw_run.sh \\
+ && mv "\$WKRUN" "\$(dirname "\$WKRUN")/pw_run.real.sh" \\
+ && printf '%s\\n' \\
+      '#!/bin/sh' \\
+      'D=\$(dirname "\$0")' \\
+      'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \\
+      'exec "\$D/pw_run.real.sh" "\$@"' \\
+      > "\$WKRUN" \\
+ && chmod +x "\$WKRUN"
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1


### PR DESCRIPTION
Our WebKit had never actually been benched. `perf-probe` skipped every non-`official` webkit target until #121, so the standing "webkit is at parity or better" line came from 2026-08-13 numbers on a binary we have since replaced. The first real measurement (run 33056825499) says otherwise, and the shape of it is what made me reach for this change:

| metric | alpine x off | ubuntu x off (null arm) |
|---|---|---|
| **goto_cold** | **1.52** | 0.99 |
| **launch** | **1.37** | 1.00 |
| click_force | 1.30 | 1.02 |
| context_page | 1.26 | 0.93 |
| goto_warm | 1.23 | 1.11 |
| screenshot | 1.05 | 1.00 |
| layout | **0.95** | 0.98 |
| int_math | **0.97** | 1.00 |
| dom_churn | **0.97** | 1.00 |

Startup and page setup are red; rendering and JS are already faster than official. That is not a "musl is slow" shape, it is a boundary — and the boundary is the allocator. WebKit does compile bmalloc/libpas in (I checked the artifact: `pas_` x80, `bmalloc` x16, `libpas` x7, with compiled-in libpas source paths, and upstream sets `USE_SYSTEM_MALLOC_DEFAULT OFF` for x86_64 with no libc condition — the musl folklore is not in this tree). But bmalloc backs `WTF::fastMalloc` only, which is WebCore and JSC: exactly the half that is already green. GLib, GObject, GStreamer, Skia, Cairo, HarfBuzz, ICU, libsoup, fontconfig and freetype go to musl's mallocng, and they are the half that is red.

`mimalloc2-insecure` already ships in the image and in the conformance runner, so nothing new is added to either, and chromium's PartitionAlloc and the Node driver stay untouched.

## Result

`runs=5`, this branch's image against main's tip, **three independent pairings, each within one runner model**:

| metric | control | this change | |
|---|---|---|---|
| **context_page** | 1.24 – 1.31 | **0.94 – 0.96** | now below official |
| **goto_cold** | 1.46 – 1.58 | **1.09 – 1.15** | biggest absolute move |
| **click_force** | 1.33 – 1.42 | **1.19 – 1.20** | |
| **screenshot** | 1.04 – 1.08 | **1.01 – 1.04** | |
| launch | 1.29 – 1.37 | 1.31 – 1.35 | unmoved |
| goto_warm | 1.17 – 1.20 | 1.23 – 1.39 | **regressed** |
| eval_rtt | 1.09 – 1.18 | 1.11 – 1.16 | flat |
| layout | 0.95 – 0.97 | 0.97 – 0.98 | flat |
| dom_churn | 1.00 – 1.04 | 0.97 – 1.00 | flat |
| int_math | 0.97 – 1.00 | 1.00 | flat |
| libm_fmod | 5.35 – 6.33 | 5.35 – 6.31 | flat (see below) |

Runs: arm `33066062789` / `33066047576` / `33065485266`, control `33065499895` / `33066056088` / `33066072554`.

Everything outside the startup cluster is flat, which is the control this wanted — an allocator change that moved `int_math` would have meant I was measuring something else.

**Two honest negatives.** `launch` does not move at all, so whatever process startup is paying, it is not this. It is also *not* the DSO-closure story that explains chromium's launch gap: our `libWPEWebKit` carries **60** `DT_NEEDED` against official's **70**, and their `MiniBrowser` has 74 — our closure is the leaner one, so that lead is dead before anyone spends a build on it. And `goto_warm` regressed in all three pairings (+0.03, +0.06, +0.20). It is a ~20 ms metric so the absolute cost is small, but it is consistent and it is the one row moving the wrong way. I have not explained it. If you would rather not take a known regression on any row, say so and I will dig before this merges rather than after.

## A methodology finding that affects the firefox and chromium arms too

**The alpine/official ratio is itself runner-CPU-dependent, so two `perf-probe` runs cannot be differenced unless they landed on the same machine** — even though each run is internally runner-divided, which is exactly what made me think they were comparable. My first attempt compared an arm on a Xeon 8370C against a control on an EPYC 7763 and read `launch` as +0.17 (a regression) and `js_alloc` as +0.13. Both vanished once paired properly.

`libm_fmod` is the free fingerprint for this: no allocator can touch it, it has CV 0.5%, and it reads **5.35 on EPYC 7763, 6.24–6.33 on EPYC 9V74, 7.65 on Xeon 8370C**. If two runs disagree on `libm_fmod`, their other ratios are not comparable. That is how the three pairings above were validated (5.35 vs 5.35; 6.31 vs 6.24 and 6.33). Worth stealing for the other two browsers.

## Shape decisions I would like a second opinion on

I wrapped `pw_run.sh` instead of editing its text. It is Playwright's file, fetched verbatim from the tag, and `Dockerfile.finalize` already `sed`s one line of it — a second textual edit is a second thing that goes quietly inert when upstream rewrites the script. The wrapper only needs `pw_run.sh` to keep resolving from `$(dirname "$0")`, which it does. Would you rather have it folded into the existing `sed` for one fewer moving part?

The conformance runner gets the same wrapper. It already carries firefox's, with the comment "conformance has to exercise the allocator we actually ship" — I think that argument binds here identically, but it does mean this PR changes what the conformance suite runs, and `conformance-webkit` is dispatch-gated so PR-green will not exercise it. **I have not dispatched one, and I am not going to without asking**: `promote-webkit` fires on *any* dispatch carrying `build_webkit=true`, from any branch, so a green conformance dispatch off this branch would also promote `wk-latest`. Say the word and I will run it.

**What I verified before asking for the build.** The lever is connected on the published image the probe actually measured, not on a Dockerfile reading: mimalloc maps into `MiniBrowser`, `WPEWebProcess` and `WPENetworkProcess` and *not* into the Node driver, with the un-wrapped image as a negative control reading false in all four. The generated conformance-runner `RUN` block was rendered out of the heredoc and executed against a fake tree, so the escaping is checked rather than hoped. Firefox's `nm -D` discriminator is worthless here and I want that on the record: `malloc` reads undefined in ours **and** in official's `libWPEWebKit`, because bmalloc never interposes global `malloc` — anyone repeating the firefox playbook will read that as "no gap" and be wrong.

I tried to A/B this on my own box first. Those numbers are void and I am not quoting them: `locator_click` is frame-quantized and reads CV 0.0% on a runner, but CV 25% there.

## Out of scope, named so it does not look forgotten

ThinLTO is off (`cmake-flags.overlay` has `-DLTO_MODE=thin` commented out over link-step RSS fears) while Alpine's own `community/webkit2gtk-6.0` APKBUILD turns it on for x86_64 alongside the clang + lld + llvm-ar we already match. This repo's chromium arms put ThinLTO alone at geomean 1.42 → 1.31. Its own branch, its own number. Two things whoever takes it will want: the overlay *does* reach the build (`Dockerfile.port` re-COPYs it before every round's `RUN`), **but `apply-and-build-port.sh` runs cmake configure only `if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]`** — so a resumed dispatch would silently ignore the new flag and hand back a flat arm that changed nothing. It has to be a cold chain, and the artifact has to be checked for LTO evidence before any number is read. Also note the overlay justifies the OFF with "same reason chromium skips is_official_build's PGO/LTO" — that rationale is stale now, chromium built those arms and they won.

## `libm_fmod` is out of scope here — filed as #126

Short version, because it cost me two wrong answers before it cost me a right one: it is **musl's `fmod`**, not JSC's lowering of `%`. Both engines call libc the same 3,000,000 times per kernel invocation (interposed and counted: 30,000,033 ours vs 30,000,057 official), per-call engine overhead is identical, and the gap appears only at large dividend-to-divisor ratios. Measured in isolation with a call-count gate so it cannot be vacuous: glibc 54.0 ms, musl 163.8 ms, and a branchless rewrite 64.5 ms that is bit-exact against musl over 6,200,323 differential comparisons.

Two earlier revisions of this description were wrong about this and I have replaced them. The first blamed JSC. The second quoted "1.32x" from a C microbench that **never called libc at all** — gcc 15 expands `fmod` inline when the divisor is a compile-time power of two, while the binary still carries `U fmod@GLIBC_2.38` from an unrelated call site, so `nm -D` cheerfully confirms a call the hot loop never makes. `-fno-builtin-fmod` plus a non-vacuity gate fixed it. Full write-up, numbers and the trap are in #126.

Nothing in this PR depends on any of that — `libm_fmod` is flat across both arms here, which is exactly what an allocator change should do to it.
