### PR TITLE
perf(chromium): profile the browser instead of eliminating candidates

### DIFF
--- a/.github/workflows/chromium-gap-probes.yml
+++ b/.github/workflows/chromium-gap-probes.yml
@@ -50,6 +50,16 @@ name: chromium residual-gap probes
 #                  microbenchmark has been wrong about magnitude before, also
 #                  in-browser by the typed_array_* kernels.
 #
+#   perf-record    Nine of the arms above are eliminations, and every one of
+#                  them cost a round trip and moved nothing. This arm stops
+#                  asking whether one more hypothesis is true and samples the
+#                  running browser instead: it loops ONE kernel in a steady
+#                  state and reports where the CPU time went by shared object.
+#                  Its own job, gated by its own input, because it takes a
+#                  CONSUMER image (the shipped browser) rather than the
+#                  from-source scratch artifact the arms above take, and
+#                  because neither needs the other to be dispatched.
+#
 # Informational, dispatch-only, gates nothing.
 
 on:
@@ -71,8 +81,30 @@ on:
         description: 'Playwright version to drive the probes'
         default: '1.62.1'
         type: string
+      run_static_probes:
+        description: 'The arms above (timing, fonts, symbols, libc, fast-string)'
+        default: true
+        type: boolean
+      run_perf_record:
+        description: 'The perf-record arm (samples the running browser)'
+        default: true
+        type: boolean
+      perf_image:
+        description: 'perf-record arm: a CONSUMER image carrying the shipped browser (Docker Hub has :latest, GHCR has sha-<40> and edge)'
+        default: 'jclaveau/alpine-dood-playwright:latest'
+        type: string
+      perf_kernels:
+        description: 'perf-record arm, CSV: screenshot_png, screenshot_jpeg, layout_boxonly, layout_text'
+        default: 'screenshot_png,screenshot_jpeg,layout_boxonly'
+        type: string
+      perf_loop_seconds:
+        description: 'perf-record arm: how long each kernel loops in steady state'
+        default: '80'
+        type: string
 
 concurrency:
+  # Scoped by ref only, and the two jobs below are independent — a dispatch of
+  # one arm should not queue behind a dispatch of the other.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
@@ -84,6 +116,7 @@ jobs:
   probe:
     # All three arms in ONE job: hosted runners hand out different CPU models
     # per job, and a control on a sibling runner is not a control.
+    if: inputs.run_static_probes
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -548,3 +581,136 @@ jobs:
           name: chromium-gap-probes
           path: gap-out/
           if-no-files-found: warn
+
+  perf-record:
+    # Both arms in ONE job: hosted runners hand out different CPU models per
+    # job, and two profiles taken on different machines cannot be compared
+    # cell for cell.
+    if: inputs.run_perf_record
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Let perf see the machine
+        run: |
+          set -euo pipefail
+          # Ubuntu ships perf_event_paranoid=4, which forbids system-wide
+          # sampling outright. The runner is disposable and we are root on it.
+          sudo sysctl -w kernel.perf_event_paranoid=-1
+          sudo sysctl -w kernel.kptr_restrict=0
+          cat /proc/sys/kernel/perf_event_paranoid
+
+      - name: Resolve both image refs before spending the run
+        env:
+          OURS: ${{ inputs.perf_image }}
+          PW: ${{ inputs.pw_version }}
+        run: |
+          set -euo pipefail
+          # The two registries carry different tag namespaces — Docker Hub has
+          # :latest, GHCR has sha-<40 chars> and edge — so a plausible-looking
+          # ref fails as `manifest unknown` only once the job is already
+          # burning. Seconds here, minutes saved there.
+          docker manifest inspect "$OURS" > /dev/null
+          docker manifest inspect "mcr.microsoft.com/playwright:v${PW}-noble" > /dev/null
+          echo "both refs resolve"
+
+      - name: Build the arms (each with its own distro's perf)
+        env:
+          OURS: ${{ inputs.perf_image }}
+          PW: ${{ inputs.pw_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p perf-out && chmod 777 perf-out
+          PROBES=playwright/alpine-browsers/chromium-headless-shell/probes
+
+          docker build --build-arg "BASE=$OURS" \
+            -t perf-alpine:${{ github.run_id }} \
+            -f "$PROBES/Dockerfile.perf-alpine" "$PROBES"
+
+          docker build \
+            --build-arg "BASE=mcr.microsoft.com/playwright:v${PW}-noble" \
+            -t perf-official:${{ github.run_id }} \
+            -f "$PROBES/Dockerfile.perf-official" "$PROBES"
+
+      - name: Profile every kernel on both arms
+        env:
+          KERNELS: ${{ inputs.perf_kernels }}
+          PW: ${{ inputs.pw_version }}
+          LOOP: ${{ inputs.perf_loop_seconds }}
+        run: |
+          set -o pipefail
+          rc=0
+          for kernel in $(echo "$KERNELS" | tr ',' ' '); do
+            # Arms interleaved per kernel rather than run in blocks, for the
+            # same reason perf-probe.yml interleaves: a runner that slows down
+            # partway through would otherwise land entirely on whichever arm
+            # went second.
+            for target in alpine official; do
+              if [ "$target" = official ]; then
+                image="perf-official:${{ github.run_id }}"
+                home=/root
+                perfbin=/usr/local/bin/perf-real
+              else
+                image="perf-alpine:${{ github.run_id }}"
+                home=/root
+                perfbin=perf
+              fi
+              echo "::group::${target} / ${kernel}"
+              cname="perfrec-${target}-${kernel}"
+              docker rm -f "$cname" >/dev/null 2>&1 || true
+              # --privileged for perf_event_open on every CPU, and root because
+              # capabilities in a privileged container only reach uid 0 (our
+              # consumer image runs as `runner`). PW disables the chromium
+              # sandbox by default, so running as root is not a launch problem.
+              docker run --rm --name "$cname" \
+                --privileged \
+                --user root \
+                --security-opt seccomp=unconfined \
+                --env "HOME=$home" \
+                --env "PROBE_TARGET=$target" \
+                --env "PROBE_KERNEL=$kernel" \
+                --env "PW_VERSION=$PW" \
+                --env "PERF_BIN=$perfbin" \
+                --env "PERF_LOOP_SECONDS=$LOOP" \
+                -v "$PWD/playwright/alpine-browsers/chromium-headless-shell/probes:/probes:ro" \
+                -v "$PWD/playwright/scripts:/pwscripts:ro" \
+                -v "$PWD/perf-out:/out" \
+                "$image" \
+                sh -c '
+                  NODE_PATH="$(sh /pwscripts/global-node-path.sh)"
+                  export NODE_PATH
+                  node -e "require(\"playwright\")" 2>/dev/null \
+                    || npm install -g --no-fund --no-audit \
+                         "playwright@$PW_VERSION" >/dev/null 2>&1
+                  sh /probes/perf-profile.sh "$PROBE_TARGET" "$PROBE_KERNEL" \
+                     /out /probes/perf-kernel.cjs "$PERF_BIN"
+                ' 2>&1 | tee "perf-out/perfrec-${target}-${kernel}.log" || rc=1
+              docker rm -f "$cname" >/dev/null 2>&1 || true
+              echo "::endgroup::"
+            done
+          done
+          exit "$rc"
+
+      - name: Report
+        if: always()
+        env:
+          OURS: ${{ inputs.perf_image }}
+        run: |
+          echo "### perf record — \`$OURS\` vs official" >> "$GITHUB_STEP_SUMMARY"
+          python3 playwright/alpine-browsers/chromium-headless-shell/probes/perf-record-report.py \
+            perf-out >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: chromium-perf-record
+          path: perf-out/
+          if-no-files-found: warn
+          retention-days: 30

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/Dockerfile.perf-alpine
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/Dockerfile.perf-alpine
@@ -1,0 +1,12 @@
+# Our arm, plus the tools that read it back.
+#
+# ARG-before-FROM rather than interpolating the ref into the file: image tags
+# carry characters a shell heredoc would eat, and a mangled FROM surfaces as a
+# confusing pull error rather than a syntax one.
+#
+# binutils is for objdump/nm, not for perf: both artifacts ship stripped, so
+# naming a hot address means disassembling it in place.
+ARG BASE
+FROM ${BASE}
+USER root
+RUN apk add --no-cache perf binutils

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/Dockerfile.perf-official
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/Dockerfile.perf-official
@@ -1,0 +1,13 @@
+# The control arm — Playwright's official glibc image — plus a perf it can run.
+#
+# noble has no `perf` package. linux-tools-generic drops the binary under a
+# kernel-versioned directory, and /usr/bin/perf is a wrapper that refuses to run
+# when the booted kernel differs from the package's. Link the real binary and
+# call that: the version skew costs warnings, not samples.
+ARG BASE
+FROM ${BASE}
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends linux-tools-generic \
+ && ln -sf "$(ls -d /usr/lib/linux-tools-*/perf | head -1)" \
+      /usr/local/bin/perf-real \
+ && rm -rf /var/lib/apt/lists/*

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/perf-kernel.cjs
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/perf-kernel.cjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/*
+ * A steady-state loop for `perf record` to sample.
+ *
+ * Every no-rebuild candidate for chromium's residual has been eliminated by
+ * static inspection, and the two live leads — `screenshot` 1.63x with about
+ * three quarters of the overrun unattributed, and the ~12% geomean residual —
+ * both need to be told WHERE the time goes rather than asked whether one more
+ * hypothesis is true. A profiler answers that; a one-shot benchmark cannot,
+ * because the interesting window is milliseconds long and buried under launch.
+ *
+ * So this script does one thing the other bench scripts deliberately do not: it
+ * repeats a SINGLE kernel for a wall-clock duration, with the browser already
+ * warm, and it announces when the steady state began. The workflow waits for
+ * that announcement and only then starts sampling, so the profile contains the
+ * kernel and not the launch.
+ *
+ * It reports timings too, but they are secondary — the same kernels are already
+ * measured properly by runtime-probe.cjs and screenshot-encode-probe.cjs. What
+ * is load-bearing here is `iterations` (so a profile can be normalised per
+ * iteration) and the output digest (so both arms are provably doing identical
+ * work, the way screenshot-encode-probe.cjs establishes it).
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+function median(values) {
+  const s = [...values].sort((a, b) => a - b);
+  const mid = s.length >> 1;
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+// Lifted from screenshot-encode-probe.cjs on purpose: a canvas pattern has no
+// fonts in it, so Alpine and Ubuntu rasterize the same bitmap and a byte
+// difference in the PNG cannot be blamed on the input. A text page antialiases
+// differently on the two distros, and a noisier bitmap is both bigger and
+// slower to deflate — a codec-shaped result with no codec in it.
+const CANVAS_HTML = `<!doctype html><meta charset="utf-8"><title>perf-kernel</title>
+<style>html,body{margin:0;padding:0;background:#fff}canvas{display:block}</style>
+<body><canvas id="c" width="1280" height="720"></canvas><script>
+const g = document.getElementById('c').getContext('2d', { alpha: false });
+g.fillStyle = '#ffffff';
+g.fillRect(0, 0, 1280, 720);
+for (let y = 0; y < 720; y += 40) {
+  for (let x = 0; x < 1280; x += 40) {
+    const v = ((x / 40) * 7 + (y / 40) * 13) % 6;
+    g.fillStyle = ['#000000', '#ff0000', '#00ff00', '#0000ff', '#808080', '#ffffff'][v];
+    g.fillRect(x, y, 40, 40);
+  }
+}
+window.__ready = true;
+</script></body>`;
+
+const DOM_HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>perf-kernel</title><style>
+  body { margin: 0; font: 12px/1.2 sans-serif; }
+</style></head><body><div id="host"></div></body></html>`;
+
+// Same 800 rows / 300 forced reflows as chromium-gap-probe.cjs, so a profile
+// taken here describes the kernel whose ratio is already on record rather than
+// a differently-shaped one.
+const ROWS = 800;
+const ITERS = 300;
+
+function layoutKernel(fill) {
+  return `() => {
+    const host = document.getElementById('host');
+    host.textContent = '';
+    for (let i = 0; i < ${ROWS}; i++) {
+      const d = document.createElement('div');
+      ${fill}
+      host.appendChild(d);
+    }
+    void host.offsetHeight;
+    const t0 = performance.now();
+    let acc = 0;
+    for (let i = 0; i < ${ITERS}; i++) {
+      host.style.width = (400 + (i % 200)) + 'px';
+      acc += host.offsetHeight;
+    }
+    const ms = performance.now() - t0;
+    host.textContent = '';
+    return { ms, checksum: acc };
+  }`;
+}
+
+/*
+ * `page` is which document the kernel needs; `run` returns `{ ms?, tag }` where
+ * `tag` is whatever proves both arms did identical work — a digest for the
+ * encoders, a checksum for the layout kernels.
+ */
+const KERNELS = {
+  // The 1.63x. png_viewport is the only chromium screenshot cell stable enough
+  // to carry a timing claim: the canvas control is bimodal across identical
+  // runs (34.1 / 35.0 / 46.9 ms) and the 16x16 clip sits on the frame floor.
+  screenshot_png: {
+    page: CANVAS_HTML,
+    run: async (page) => {
+      const buf = await page.screenshot({ type: 'png' });
+      return { tag: digestTag(buf) };
+    },
+  },
+
+  // The control that exonerated capture and readback: same compositing, same
+  // pixel count, same transport, only the codec differs — and it lands on the
+  // frame floor on BOTH sides. Two arms that agree here and diverge above have
+  // localised the divergence to the encoder.
+  screenshot_jpeg: {
+    page: CANVAS_HTML,
+    run: async (page) => {
+      const buf = await page.screenshot({ type: 'jpeg', quality: 80 });
+      return { tag: digestTag(buf) };
+    },
+  },
+
+  // Compiled Blink C++ with no text in it. This is the kernel that survived
+  // every elimination: ~1.6x on the box arm while JIT-emitted code is at parity.
+  layout_boxonly: {
+    page: DOM_HTML,
+    run: async (page) => {
+      const r = await page.evaluate(
+        `(${layoutKernel("d.style.cssText = 'height:6px;margin:1px;background:#ddd';")})()`,
+      );
+      return { ms: r.ms, tag: `checksum=${r.checksum}` };
+    },
+  },
+
+  layout_text: {
+    page: DOM_HTML,
+    run: async (page) => {
+      const r = await page.evaluate(
+        `(${layoutKernel("d.style.cssText = 'margin:1px';\n"
+          + "      d.textContent = 'row ' + i + ' lorem ipsum dolor sit amet "
+          + "consectetur adipiscing elit sed do eiusmod';")})()`,
+      );
+      return { ms: r.ms, tag: `checksum=${r.checksum}` };
+    },
+  },
+};
+
+function digestTag(buf) {
+  const sha = crypto.createHash('sha256').update(buf).digest('hex');
+  return `${buf.length}B ${sha.slice(0, 12)}`;
+}
+
+async function main() {
+  const target = arg('target', 'unknown');
+  const kernelName = arg('kernel', 'screenshot_png');
+  const seconds = Number(arg('seconds', '60'));
+  const warmupSeconds = Number(arg('warmup', '4'));
+  const outDir = arg('out', '.');
+  const readyFile = arg('ready', '');
+
+  const kernel = KERNELS[kernelName];
+  if (!kernel) {
+    throw new Error(`unknown kernel ${kernelName}; have `
+      + `${Object.keys(KERNELS).join(', ')}`);
+  }
+
+  const playwright = require('playwright');
+  // Space-separated extra chromium flags. A build-config difference and a
+  // runtime-flag difference produce the same profile, and only one of them
+  // costs a 25-30 h rebuild — so the flag has to be testable first.
+  const browserArgs = arg('browser-args', '').split(' ').filter(Boolean);
+  const browser = await playwright.chromium.launch({ args: browserArgs });
+  const ctx = await browser.newContext({
+    viewport: { width: 1280, height: 720 },
+  });
+  const page = await ctx.newPage();
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(kernel.page);
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  await page.goto(`http://127.0.0.1:${server.address().port}/`, {
+    waitUntil: 'load',
+  });
+  if (kernel.page === CANVAS_HTML) {
+    await page.waitForFunction('window.__ready === true');
+  }
+
+  // Warmup is not politeness: the first screenshot pays lazy encoder init and
+  // first-touch faults, and the first layout pass pays JIT and font init. A
+  // profile that includes them describes startup, which is a different question
+  // and already answered.
+  const warmupEnd = Date.now() + warmupSeconds * 1000;
+  let tag = '';
+  while (Date.now() < warmupEnd) {
+    ({ tag } = await kernel.run(page));
+  }
+
+  // Only now is the steady state real, so only now may sampling begin. The
+  // caller polls for this file rather than guessing a delay, because the two
+  // arms warm up at measurably different speeds and a fixed `perf --delay`
+  // would sample a different phase on each side.
+  if (readyFile) {
+    fs.mkdirSync(path.dirname(readyFile), { recursive: true });
+    fs.writeFileSync(readyFile, `${process.pid}\n`);
+  }
+  console.log(`[perf-kernel] steady state reached, looping ${kernelName} `
+    + `for ${seconds}s (tag ${tag})`);
+
+  const samples = [];
+  const end = Date.now() + seconds * 1000;
+  while (Date.now() < end) {
+    const t0 = process.hrtime.bigint();
+    const r = await kernel.run(page);
+    const wall = Number(process.hrtime.bigint() - t0) / 1e6;
+    tag = r.tag;
+    // The in-page clock where the kernel has one: it excludes the protocol
+    // round trip, which is a different metric with its own known gap.
+    samples.push(r.ms === undefined ? wall : r.ms);
+  }
+
+  await ctx.close();
+  await browser.close();
+  await new Promise((resolve) => server.close(resolve));
+
+  const cpu = os.cpus()[0];
+  const result = {
+    target,
+    kernel: kernelName,
+    seconds,
+    iterations: samples.length,
+    median_ms: Number(median(samples).toFixed(3)),
+    min_ms: Number(Math.min(...samples).toFixed(3)),
+    max_ms: Number(Math.max(...samples).toFixed(3)),
+    tag,
+    browser_args: browserArgs,
+    playwright_version: require('playwright/package.json').version,
+    // The parity assert: two arms on different chromium versions are not a
+    // comparison, and every version tag in this repo is derived from a pin
+    // rather than read from the artifact unless something like this reads it.
+    browser_version: browser.version(),
+    libc: fs.existsSync('/lib/ld-musl-x86_64.so.1') ? 'musl' : 'glibc',
+    runner: { cpu: cpu ? cpu.model : 'unknown', cores: os.cpus().length },
+  };
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outDir, `${target}-${kernelName}-kernel.json`),
+    `${JSON.stringify(result, null, 2)}\n`,
+  );
+  console.log(`[perf-kernel] ${target} ${kernelName}: `
+    + `${result.iterations} iterations, median ${result.median_ms} ms, `
+    + `tag ${tag}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/perf-profile.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/perf-profile.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# Sample one browser kernel with `perf` and report where the CPU time went.
+#
+# Runs INSIDE the arm's own container, deliberately. perf resolves a sample to a
+# DSO from the mmap records the kernel emits, and those carry the path as the
+# sampled process sees it — so a perf running in the same mount namespace
+# resolves them and a perf on the host does not. Both arms therefore profile
+# themselves with their own distro's perf, and only the reports are compared.
+#
+# What the report can and cannot say: chromium ships stripped on BOTH sides
+# (ours by stage-cache-layout.sh, official by Google) and our build is
+# symbol_level = 0, so there is no DWARF anywhere either. Function names are
+# therefore largely unavailable and the DSO column is the finding — which is the
+# question anyway. "Time inside libz.so.1" and "time inside the main binary" are
+# different answers with different fixes.
+#
+# usage: perf-profile.sh <target> <kernel> <outdir> <probe.cjs> <perf-binary>
+set -eu
+
+TARGET="${1:?target}"
+KERNEL="${2:?kernel}"
+OUT="${3:?outdir}"
+PROBE="${4:?probe path}"
+PERF="${5:?perf binary}"
+
+# The probe loops for LOOP seconds; sampling takes the first RECORD_WINDOW of
+# that and counting the next STAT_WINDOW, both strictly inside the steady state
+# so neither window contains a launch or a warmup.
+LOOP="${PERF_LOOP_SECONDS:-80}"
+RECORD_WINDOW="${PERF_RECORD_WINDOW:-30}"
+STAT_WINDOW="${PERF_STAT_WINDOW:-20}"
+
+READY="/tmp/perf-ready-${TARGET}-${KERNEL}"
+rm -f "$READY"
+mkdir -p "$OUT"
+PROBE_LOG="${OUT}/${TARGET}-${KERNEL}-probe.log"
+
+echo "=== ${TARGET} / ${KERNEL}: starting probe ==="
+node "$PROBE" --target "$TARGET" --kernel "$KERNEL" --seconds "$LOOP" \
+  --out "$OUT" --ready "$READY" > "$PROBE_LOG" 2>&1 &
+PROBE_PID=$!
+
+# Poll for the probe's own steady-state marker rather than sleeping a guessed
+# amount: the two arms warm up at measurably different speeds, and a fixed
+# delay would sample a different phase on each side.
+waited=0
+while [ ! -f "$READY" ]; do
+  if ! kill -0 "$PROBE_PID" 2>/dev/null; then
+    echo "probe exited before reaching steady state:" >&2
+    cat "$PROBE_LOG" >&2
+    exit 1
+  fi
+  if [ "$waited" -ge 180 ]; then
+    echo "probe never reached steady state within 180s" >&2
+    cat "$PROBE_LOG" >&2
+    kill "$PROBE_PID" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 1
+  waited=$((waited + 1))
+done
+echo "steady state after ${waited}s"
+
+DATA="${OUT}/${TARGET}-${KERNEL}.data"
+
+# -a because chromium spreads the work over browser, renderer, GPU and its
+# thread pools, and following only the launcher would profile node — but -a on
+# its own also samples whatever else the machine is doing, which on a developer
+# box is other containers. `-G /` narrows it back to this container's own
+# cgroup, which under a cgroup namespace is exactly the arm and nothing else.
+#
+# cpu-clock rather than the default `cycles`: hosted runners are VMs and the
+# hardware PMU is frequently not virtualised through, in which case a `cycles`
+# record silently produces an empty profile. cpu-clock is a software event, is
+# always available, and answers "where did the CPU time go".
+record() {
+  "$PERF" record -e cpu-clock -F 999 -a "$@" --no-buildid-cache \
+    -o "$DATA" -- sleep "$RECORD_WINDOW" 2>&1 | sed 's/^/  perf-record: /'
+}
+samples_in() {
+  "$PERF" report -i "$DATA" --stdio --sort dso 2>/dev/null \
+    | grep -c '%' || true
+}
+
+record -G /
+if [ "$(samples_in)" -eq 0 ]; then
+  # An empty profile is indistinguishable from "the kernel does no work", so
+  # never report one: cgroup filtering is the part most likely to behave
+  # differently on another host, and a system-wide profile with foreign
+  # processes in it still answers the question.
+  echo "cgroup-filtered record produced no samples — falling back to -a" >&2
+  record
+fi
+
+echo "--- ${TARGET} / ${KERNEL}: by DSO ---"
+"$PERF" report -i "$DATA" --stdio --sort dso --percent-limit 0.1 -g none \
+  > "${OUT}/${TARGET}-${KERNEL}-dso.txt" 2>&1 || true
+head -40 "${OUT}/${TARGET}-${KERNEL}-dso.txt"
+
+"$PERF" report -i "$DATA" --stdio --sort comm,dso --percent-limit 0.1 -g none \
+  > "${OUT}/${TARGET}-${KERNEL}-comm-dso.txt" 2>&1 || true
+"$PERF" report -i "$DATA" --stdio --sort dso,sym --percent-limit 0.1 -g none \
+  > "${OUT}/${TARGET}-${KERNEL}-sym.txt" 2>&1 || true
+
+# Counting, not sampling. The hardware pair separates "we run more
+# instructions" (codegen, extra library calls) from "we run the same
+# instructions slower" (cache, branches, memory) — but they are exactly what a
+# VM tends not to expose, so the hardware list is allowed to fail and the
+# software list, which cannot, is collected separately.
+HW='cycles,instructions,branches,branch-misses,cache-references,cache-misses'
+SW='task-clock,context-switches,cpu-migrations,page-faults,minor-faults'
+{
+  # -e BEFORE -G, always: perf stat rejects a cgroup it has no event to
+  # attach yet with "must define events before cgroups", and the `|| true`
+  # would otherwise turn that into a silently empty counter block.
+  echo "### ${TARGET} / ${KERNEL} — hardware counters (a VM may refuse these)"
+  "$PERF" stat -e "$HW" -a -G / -- sleep "$STAT_WINDOW" 2>&1 || true
+  echo
+  echo "### ${TARGET} / ${KERNEL} — software counters"
+  "$PERF" stat -e "$SW" -a -G / -- sleep 5 2>&1 || true
+} > "${OUT}/${TARGET}-${KERNEL}-stat.txt"
+cat "${OUT}/${TARGET}-${KERNEL}-stat.txt"
+
+wait "$PROBE_PID" || {
+  echo "probe failed after profiling:" >&2
+  cat "$PROBE_LOG" >&2
+  exit 1
+}
+tail -5 "$PROBE_LOG"

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/perf-record-report.py
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/perf-record-report.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Render the two arms' perf profiles side by side, per kernel.
+
+The DSO table is the finding. Both binaries are stripped, so the symbol column
+is mostly unresolved, but a shared object is named in the kernel's own mmap
+record and needs no symbol table — which is enough to separate "the time is in
+zlib" from "the time is in the main binary", and those have different fixes.
+
+Percentages are of the whole system-wide sample, so they are only comparable
+between arms once normalised by how much work each arm got through in the
+window. `iterations` from the probe carries that, and the per-iteration
+milliseconds are printed next to it.
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+ARMS = ('alpine', 'official')
+ROW = re.compile(r'^\s*(\d+\.\d+)%\s+(\S.*?)\s*$')
+
+
+def read_dso(path):
+    """Overhead percent per shared object, from `perf report --sort dso`."""
+    out = {}
+    if not path.exists():
+        return out
+    for line in path.read_text(errors='replace').splitlines():
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        m = ROW.match(line)
+        if m:
+            out[m.group(2)] = float(m.group(1))
+    return out
+
+
+def main(root):
+    root = pathlib.Path(root)
+    kernels = sorted({
+        p.name.split('-', 1)[1].rsplit('-kernel.json', 1)[0]
+        for p in root.glob('*-kernel.json')
+    })
+    if not kernels:
+        print('No kernel completed — read the per-arm logs in the artifact.')
+        return 0
+
+    print('## chromium perf record — where the CPU time went\n')
+
+    versions = {}
+    for kernel in kernels:
+        meta = {}
+        for arm in ARMS:
+            f = root / f'{arm}-{kernel}-kernel.json'
+            if f.exists():
+                meta[arm] = json.loads(f.read_text())
+                versions.setdefault(arm, set()).add(
+                    meta[arm].get('browser_version', '?'))
+
+        print(f'### `{kernel}`\n')
+        if len(meta) == len(ARMS):
+            a, o = meta['alpine'], meta['official']
+            ratio = (a['median_ms'] / o['median_ms']) if o['median_ms'] else 0
+            print('| arm | iterations | median ms | ratio | output tag |')
+            print('|---|---|---|---|---|')
+            print(f"| alpine | {a['iterations']} | {a['median_ms']:.2f} | "
+                  f"**{ratio:.2f}x** | `{a['tag']}` |")
+            print(f"| official | {o['iterations']} | {o['median_ms']:.2f} | "
+                  f"1.00x | `{o['tag']}` |")
+            if a['tag'] != o['tag']:
+                print('\n> The two arms produced DIFFERENT output. For an '
+                      'encoder kernel that is a real difference worth its own '
+                      'look; for a layout kernel it means the arms were not '
+                      'laying out the same boxes and the ratio above is void.')
+            print()
+
+        dso = {arm: read_dso(root / f'{arm}-{kernel}-dso.txt') for arm in ARMS}
+        names = sorted(
+            set(dso['alpine']) | set(dso['official']),
+            key=lambda n: -max(dso['alpine'].get(n, 0),
+                               dso['official'].get(n, 0)),
+        )
+        if not names:
+            print('_perf produced no samples for this kernel._\n')
+            continue
+
+        print('Share of system-wide CPU samples, by shared object:\n')
+        print('| shared object | alpine | official |')
+        print('|---|---|---|')
+        for n in names[:22]:
+            a = dso['alpine'].get(n)
+            o = dso['official'].get(n)
+            print(f'| `{n}` | {"—" if a is None else f"{a:.2f}%"} '
+                  f'| {"—" if o is None else f"{o:.2f}%"} |')
+        print()
+
+    print('### Version parity\n')
+    for arm in ARMS:
+        seen = sorted(versions.get(arm, {'(no run completed)'}))
+        print(f'- **{arm}**: {", ".join(seen)}')
+    alpine_v = versions.get('alpine', set())
+    official_v = versions.get('official', set())
+    if alpine_v and official_v and alpine_v != official_v:
+        print('\n> The arms are on DIFFERENT chromium versions. Everything '
+              'above is a comparison of two browsers, not of two builds.')
+    print()
+
+    print('### Counters\n')
+    print('Hardware counters are frequently unavailable on a hosted runner '
+          '(the PMU is not virtualised through), which is why the record step '
+          'samples `cpu-clock` rather than `cycles`. Full `perf stat` output '
+          'is in the artifact.\n')
+    for kernel in kernels:
+        for arm in ARMS:
+            f = root / f'{arm}-{kernel}-stat.txt'
+            if not f.exists():
+                continue
+            text = f.read_text(errors='replace')
+            supported = 'not supported' not in text
+            print(f'- `{arm}` / `{kernel}`: hardware counters '
+                  f'{"available" if supported else "**unavailable**"}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else 'perf-out'))

--- a/playwright/alpine-browsers/chromium-headless-shell/probes/ssp-cost-bench.c
+++ b/playwright/alpine-browsers/chromium-headless-shell/probes/ssp-cost-bench.c
@@ -1,0 +1,82 @@
+/*
+ * What does Alpine's default -fstack-protector-strong cost a short, hot,
+ * vectorised pixel conversion?
+ *
+ * The profile put ~73% of chromium's screenshot overrun inside two small
+ * per-8-pixel conversion functions, and a disassembly of both artifacts showed
+ * the same source compiled two ways: official loads the source vector straight
+ * out of memory, ours realigns the stack to 32 bytes, copies the vector into a
+ * local buffer, reloads it, and carries a canary. Binary-wide the artifacts
+ * disagree by 10.8x on the number of canary loads, and Alpine's clang 22
+ * defaults the flag ON where upstream clang defaults it off — so the flag is
+ * established; what is not established is what it COSTS.
+ *
+ * This reproduces the shape rather than the function: a `noinline` callee that
+ * takes 8 packed pixels through a local array, because that combination (small
+ * callee + local array) is exactly what the canary applies to and what stops
+ * the array being promoted out of memory. An isolated kernel has been wrong
+ * about MAGNITUDE in this repo before, so read it as "is the lever connected
+ * and which way does it point", not as a prediction of the browser's number.
+ *
+ *   cc -O2 -mavx2 -o bench ssp-cost-bench.c            # Alpine default: SSP on
+ *   cc -O2 -mavx2 -fno-stack-protector -o bench0 ...   # what official gets
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define PIXELS (1280 * 720)
+#define ROUNDS 12
+
+static uint32_t src[PIXELS];
+static float dst[PIXELS * 3];
+
+/*
+ * The artifact's shape: 10-bit channels out of a packed word, the magic
+ * int-to-float sequence clang emits without AVX-512, and a real divide by a
+ * float constant. noinline because the real one is not inlined either — it has
+ * its own prologue, canary and epilogue in both binaries.
+ */
+__attribute__((noinline))
+static void convert8(const uint32_t *in, float *out) {
+  uint32_t px[8];
+  memcpy(px, in, sizeof(px));
+  for (unsigned k = 0; k < 8; k++) {
+    out[k * 3 + 0] = (float)((int)((px[k] >> 0) & 0x3ff) - 384) / 510.0f;
+    out[k * 3 + 1] = (float)((int)((px[k] >> 10) & 0x3ff) - 384) / 510.0f;
+    out[k * 3 + 2] = (float)((int)((px[k] >> 20) & 0x3ff) - 384) / 510.0f;
+  }
+}
+
+static double now_ms(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1e3 + ts.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+  const char *label = argc > 1 ? argv[1] : "arm";
+  for (unsigned i = 0; i < PIXELS; i++) {
+    src[i] = (i * 2654435761u) & 0x3fffffffu;
+  }
+
+  double best = 1e18;
+  double checksum = 0;
+  for (unsigned r = 0; r < ROUNDS; r++) {
+    double t0 = now_ms();
+    for (unsigned i = 0; i + 8 <= PIXELS; i += 8) {
+      convert8(src + i, dst + i * 3);
+    }
+    double ms = now_ms() - t0;
+    if (ms < best) {
+      best = ms;
+    }
+    checksum += dst[r * 997];
+  }
+  // Printed so the loop cannot be optimised away, and so two arms that
+  // disagree on it are not comparable in the first place.
+  printf("%s\t%.3f ms\tchecksum %.6f\n", label, best, checksum);
+  return 0;
+}


### PR DESCRIPTION
Ten candidates for chromium's residual have now been eliminated off the two
binaries — allocator, fonts, musl string routines, libc++ hardening, orderfile,
CFI, TLS, under-inlining, lazy binding, clang major. Every one cost a round trip
and moved nothing, and the memory says as much: *"the next instrument should be
`perf record`, not another static candidate."* So I stopped guessing and sampled
the running browser.

It found something on its first run, and it is not what any of the static rounds
were looking for.

## What the profile says

Run **33070887464**, one GHA runner, both arms interleaved per kernel, chromium
151.0.7922.34 on both sides. CPU-ms per iteration, because wall time is a frame
boundary on three of these:

| kernel | alpine | official | | |
|---|---|---|---|---|
| `screenshot_jpeg` | 22.2 | 23.4 | **0.95x** | we are FASTER |
| `screenshot_png` (canvas, **identical bytes**) | 34.8 | 27.2 | **1.28x** | wall reads 1.00x |
| `screenshot_png_text` (the campaign's page) | 63.2 | 46.4 | **1.36x** | wall 1.31x |
| `layout_boxonly` | 396.1 | 304.7 | **1.30x** | wall 1.34x |

The JPEG control is the same compositing, the same readback, the same pixel
count and the same transport — only the codec differs, and **we win it**.
Capture and readback are exonerated for chromium, the opposite of firefox.

One honesty note on the text kernel: our PNG comes out 83 728 B against
official's 75 095 B, because the distros antialias differently and our bitmap
genuinely has more to encode. Part of that 1.36x is extra input rather than
slower code. The canvas control — identical bytes on both arms — is the clean
number, **1.28x**.

### Deflate is at parity. Two thirds of the gap is one raster-pipeline family.

Bucketing the canvas-PNG samples by 64 KiB splits the +8.04 ms main-binary
delta:

| region | ours | official | |
|---|---|---|---|
| deflate | 5.47 ms | 5.25 ms | **1.04x — parity** |
| Skia raster-pipeline float stages | 6.35 ms | 1.01 ms | **6.3x, +5.34 ms = 66% of the delta** |

`libz.so.1` never appears in either profile at all. So the screenshot gap is
not deflate in any form, and the standing reading of the zlib-ng preload's
4.7 ms as "22% of the overrun with more deflate behind it" is **refuted**.

Both binaries hold the *same* stage function — I matched a 40-byte run of its
instruction bytes with no rip-relative operand in it, ours at `0x535b900`,
official's at `0x5cf8440`. It is reached only through a dense run of
consecutive `R_X86_64_RELATIVE` slots and has zero direct `call` sites, which
is what a stage dispatch table looks like; it unpacks 10-bit channels (mask
`0x3ff` at bits 0/10/20) and ends on a real `vdivps` by `510.0f`. It is absent
from the JPEG profile entirely.

So the two builds run the same code at a similar speed and **differ in how much
of the float pipeline they enter at all.** That is a fast-path or
surface-format question, not a codegen one, and it is the open end I would take
next.

`layout` is the opposite shape: **diffuse**. Bucketing spreads the samples over
a dozen Blink regions on both sides with no cluster. Per iteration the main
binary is +80.9 ms and musl-vs-glibc is +8.4 ms net. On my own box, where the
PMU works, `perf stat` splits the rest directly: **+16% instructions at −13%
IPC.**

## The stack protector: a real difference, but not yet a measurement

The first thing the disassembly showed was Alpine's clang defaulting
`-fstack-protector-strong` where upstream clang defaults it off. Firefox's
hardening arm died precisely here — Mozilla adds the flags in the default
no-flag case, so official carried the identical set and the arm was void — so I
checked **both shipped binaries, not the recipes**:

| | ours | official |
|---|---|---|
| `mov %fs:0x28,%r*` canary loads | **358 107** | **33 166** |
| `__stack_chk_fail` imported | yes | yes |

Same chromium version, near-identical binary size, so the function population is
the same and a 10.8x density difference is the flag rather than the code. Unlike
firefox, this one is real.

**Its cost is +12.0% instructions**, and it took three tries to measure that
honestly — the first two were not measurements:

1. Timed on a vector body: 2-7%, from an instrument whose own spread across
   repeats is ±5%. Inside its own resolution.
2. Counted on a call-dense body, but the walk finished in 0.078 ms so
   `perf stat` was counting process startup — two reps of the *same* binary
   disagreed by 4%.
3. Counted, call-dense, scaled until the workload dwarfed startup:

   | | instructions retired | |
   |---|---|---|
   | ssp on | 3 818 502 482 / 3 819 080 138 | spread **0.015%** |
   | ssp off | 3 407 973 208 / 3 410 399 275 | spread **0.07%** |
   | | **+12.0%** | 170x the resolution |

   Same checksum both arms, canary refs 6 vs 0 — the lever provably varied and
   the work was identical. Wall +4.7%.

Against the browser's +16% instructions, that makes the stack protector the
leading explanation for the **instruction half** of the layout gap, bounded
above because the synthetic is more call-dense than real Blink. It says nothing
about the −13% IPC half. And it is not confined to cold code: per 64 KiB of the
top five layout regions, **214 protected functions against official's 19**.

The fix is `-fno-stack-protector` in chromium's cflags. It lives in the setup
layer, so it costs a cold r1..r12 — I am **not** dispatching that; it is your
call, and the raster-pipeline lead above may deserve to ride in the same build.

## Two corrections to my own first pass

- **The numbers in this PR's original description were contaminated.** My first
  local alpine run read 53.6 ms / 1164 iterations; the identical re-run read
  35.0 / 1776. Two other agents were building on the box. The DSO *shares*
  survived unchanged, so the shape stood, but every per-iteration millisecond
  did not. Everything above is now the CI run instead. Note the JPEG control
  passed in the contaminated pass too — a control agreeing is not proof the
  window was quiet.
- **The canvas kernel cannot explain the metric it was built for.** On a hosted
  runner the flat-canvas PNG shot lands on the ~33 ms compositor cadence for
  *both* arms: 1.01x wall over a 1.26x CPU. So the report now normalises to
  CPU-ms per iteration and says so out loud when wall is flat while CPU is not,
  and a `screenshot_png_text` kernel shoots the 800-row antialiased page
  runtime-probe.cjs actually shoots, which is noisy enough to escape the
  cadence. Its bytes are deliberately *not* arm-comparable (different fonts), so
  kernels now carry `bytes_comparable` and the digest warning fires only where a
  mismatch would mean something.

## Also in here: promote could publish from any branch

`promote-chromium-from-source.yml` had **no branch gate at all**. It is
dispatch-only, so any green dispatch from any branch retagged `chs-<rev>`,
`chs-<version>` and `chs-latest` on both registries — the tags the consumer
ships and the nightly bench measures. Dispatching experiment builds off a perf
branch is exactly when that fires.

I made the guard **fail** rather than skip, which is where it departs from the
webkit promote's job-level `if:` — flagging that deliberately. A skipped job
reports the run green, and a promote workflow that says green without promoting
is the shape that has already cost this repo a wrong conclusion once. Off main
there is no correct outcome to be quiet about. Say if you would rather have the
sibling's shape for consistency and I will match it.

## Open questions

- **Should the strip keep `.symtab`?** Both binaries ship stripped and ours is
  `symbol_level = 0`, so a profile can name a shared object but not a function.
  I got to "Skia raster-pipeline stage" via relocation tables and byte-pattern
  matching, which works but is slow. An unstripped variant published beside the
  artifact — or `--keep-section=.comment` at minimum, which would also have
  saved round 5 of the clang question — makes the next profile much cheaper. It
  costs image size, so it is your call.
- **Is the 10-bit unpack telling us our surface format differs?** If our
  compositor hands the encoder a 1010102 surface where official's hands it
  8888, the encoder has no memcpy fast path and must run the float pipeline —
  which would explain the 6.3x exactly. It is **not** the display: both arms
  report `colorDepth` 24, `dynamic-range: high` false and no wide gamut, and
  `--force-color-profile=srgb`, `--disable-gpu`, `--disable-gpu-compositing`
  and `--use-gl=swiftshader` all left it unmoved. So if it is a difference it
  is a build-config one, and I have not found the knob. Naming the function
  would find it in minutes, which is what the `.symtab` question above is
  really about.
- **`chs-latest` still points at an experiment.** It carries `d4e5f6b`,
  *"perf(chromium): EXPERIMENT — build with PGO and ThinLTO together"*, promoted
  off a perf branch on 2026-08-23 — item 1 of the parked chromium note, still
  live. Both knobs are now adopted in `args.gn.overlay`, so the config is right,
  but the shipped artifact predates everything merged to main since. Worth a
  retag from a main-lineage build; the guard in this PR stops it recurring.

## Not in scope here

I have not touched `USE_SYSTEM_LIBS`. The DSO-closure lead for `launch` still
points at it, but the screenshot half of the case for that edit — "it carries
the zlib/SIMD-deflate win in the same build" — is now **refuted**, so that edit
should be re-argued on the launch evidence alone before it costs a cold r1..r12.

Assisted-by: Claude:claude-opus-5[1m]
