### PR TITLE
perf(webkit): replace musl's fmod under WebKit, gated on bit-exactness

### DIFF
--- a/.github/workflows/wk-fastfmod-gate.yml
+++ b/.github/workflows/wk-fastfmod-gate.yml
@@ -1,0 +1,66 @@
+name: WebKit fastfmod gate
+
+# Proves that libfastfmod.so — the `fmod` we preload under WebKit — returns
+# bit-identical results to musl's own fmod, before it can ship.
+#
+# This is a real gate rather than a smoke test because the object interposes a
+# libm function underneath a browser. The differential run is the load-bearing
+# artifact, so it lives here and re-runs on every change rather than sitting in
+# a transcript somewhere.
+#
+# It runs inside the same alpine base the consumer image is built from, so the
+# musl it verifies against is the musl it will ship against.
+
+on:
+  pull_request:
+    paths:
+      - 'playwright/alpine-browsers/webkit/fastfmod/**'
+      - 'playwright/Dockerfile.alpine'
+      - '.github/workflows/wk-fastfmod-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'playwright/alpine-browsers/webkit/fastfmod/**'
+      - '.github/workflows/wk-fastfmod-gate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: wk-fastfmod-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    container:
+      image: alpine:edge
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Toolchain
+        run: apk add --no-cache gcc musl-dev bash
+
+      - name: Report the libc under test
+        # Which musl this ran against belongs in the log: the whole claim is
+        # "bit-identical to THIS libc's fmod".
+        run: |
+          set -eu
+          apk info musl | head -2
+          ls -l /lib/ld-musl-x86_64.so.1
+
+      - name: Differential gate
+        # run-gate.sh fails the job on: fmod being inlined away (which would
+        # make the comparison vacuous), the preload not loading (ld.so only
+        # warns), any bucket digest differing, or a deliberately corrupted
+        # build being accepted.
+        run: sh playwright/alpine-browsers/webkit/fastfmod/run-gate.sh
+             playwright/alpine-browsers/webkit/fastfmod
+             "$RUNNER_TEMP/fastfmod-gate"
+
+      - name: Keep the digests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fastfmod-gate
+          path: ${{ runner.temp }}/fastfmod-gate/*.txt
+          if-no-files-found: warn

--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -14,6 +14,38 @@ FROM ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} AS chs-source
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} AS ff-source
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:wk-${WK_REV} AS wk-source
 
+# libfastfmod.so — a drop-in `fmod` for musl, preloaded under WebKit alongside
+# mimalloc. musl's fmod walks the exponent difference one bit per iteration
+# with a data-dependent branch, so for large dividends every call eats ~21
+# unpredictable branches: 163.8 ms per 3M calls against glibc's 54.0. That is
+# the whole of `libm_fmod`, our largest per-metric gap on any browser (5.35x on
+# an EPYC 7763, 7.65x on a Xeon 8370C) — both engines call libc the same
+# 3,000,000 times per kernel, so it was never JSC. See issue #126.
+#
+# Compiled here and gated in .github/workflows/wk-fastfmod-gate.yml, which runs
+# the same operand stream with and without it and compares raw result bits.
+# The smoke below is only a build-time sanity check that the object loads and
+# answers; bit-exactness is the workflow's job, over 7.5M comparisons.
+FROM ${BASE_IMAGE} AS fastfmod-build
+COPY alpine-browsers/webkit/fastfmod /work/fastfmod
+RUN sudo apk add --no-cache gcc musl-dev \
+ && sudo gcc -O2 -fPIC -shared -o /usr/lib/libfastfmod.so /work/fastfmod/fastfmod.c \
+ && printf '%s\n' \
+      '#include <stdio.h>' \
+      '#include <math.h>' \
+      'int main(void){' \
+      '  /* k*y + r with k=1e6, y=2^32, r=12345: a ~32-bit exponent gap, and' \
+      '     exactly representable since doubles have unit spacing below 2^52. */' \
+      '  if (fmod(1000000.0 * 4294967296.0 + 12345.0, 4294967296.0) != 12345.0) return 1;' \
+      '  if (fmod(7.5, 2.0) != 1.5) return 2;' \
+      '  if (fmod(-7.5, 2.0) != -1.5) return 3;' \
+      '  if (!isnan(fmod(1.0, 0.0))) return 4;' \
+      '  if (fmod(3.0, INFINITY) != 3.0) return 5;' \
+      '  puts("fastfmod smoke ok"); return 0; }' \
+    > /tmp/smoke.c \
+ && gcc -O2 -fno-builtin-fmod -o /tmp/smoke /tmp/smoke.c -lm \
+ && LD_PRELOAD=/usr/lib/libfastfmod.so /tmp/smoke
+
 # Runtime libs. chromium-headless-shell has RPATH=$ORIGIN but the FROM-SOURCE
 # build (unlike the old apk one) is NOT fully self-contained — it dynamically
 # links Alpine's libxslt + double-conversion + minizip + crc32c (aports chromium
@@ -145,12 +177,19 @@ RUN sudo touch /ms-playwright/webkit-${WK_REV}/INSTALLATION_COMPLETE \
 # PW-side rewrite of that script cannot silently drop it. pw_run.sh resolves
 # everything from `$(dirname "$0")`, so it is indifferent to being renamed
 # inside its own directory.
+#
+# The same wrapper carries libfastfmod.so (built in the fastfmod-build stage
+# above). Both entries are plain interpositions of disjoint symbols, so the
+# order between them does not matter. If either object fails to load, ld.so
+# warns on stderr and continues: WebKit still runs and still returns correct
+# results, just at musl's allocator and musl's fmod speed. There is no
+# correctness dependency on the preload succeeding.
 RUN sudo mv /ms-playwright/webkit-${WK_REV}/pw_run.sh \
             /ms-playwright/webkit-${WK_REV}/pw_run.real.sh \
  && printf '%s\n' \
         '#!/bin/sh' \
         'DIR="$(dirname "$0")"' \
-        'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \
+        'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2:/usr/lib/libfastfmod.so' \
         'exec "$DIR/pw_run.real.sh" "$@"' \
   | sudo tee /ms-playwright/webkit-${WK_REV}/pw_run.sh >/dev/null \
  && sudo chmod +x /ms-playwright/webkit-${WK_REV}/pw_run.sh
@@ -227,6 +266,11 @@ ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 # run the container with `--security-opt seccomp=unconfined` (documented in the
 # image README) — the two are required together (see the producer Tier-2 smoke).
 ENV WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
+
+# The fmod interposer the webkit launcher preloads. ~10 kB; reaches
+# MiniBrowser and every auxiliary process, and nothing else — not the Node
+# driver, not chromium, not firefox.
+COPY --from=fastfmod-build /usr/lib/libfastfmod.so /usr/lib/libfastfmod.so
 
 RUN pnpm install -g playwright@${PLAYWRIGHT_VERSION}
 

--- a/playwright/alpine-browsers/conformance/build-runner.sh
+++ b/playwright/alpine-browsers/conformance/build-runner.sh
@@ -32,6 +32,9 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # combined image's Dockerfile.alpine context COPY).
 cp "$(dirname "$0")/../webkit/scripts/strip-bundled-libs.sh" "$TMPDIR/"
 cp "$(dirname "$0")/../webkit/scripts/strip-mesa-closure.sh" "$TMPDIR/"
+# The fmod interposer the webkit launcher preloads: conformance has to run
+# the same libm the image ships, or it validates a build nobody runs.
+cp -r "$(dirname "$0")/../webkit/fastfmod" "$TMPDIR/"
 
 case "$BROWSER" in
   chromium)
@@ -421,18 +424,23 @@ COPY strip-bundled-libs.sh /tmp/strip-bundled-libs.sh
 RUN bash /tmp/strip-mesa-closure.sh /ms-playwright/webkit-${ARTIFACT_REV}/minibrowser-wpe \\
  && bash /tmp/strip-bundled-libs.sh /ms-playwright/webkit-${ARTIFACT_REV}/minibrowser-wpe webkit \\
  && touch /ms-playwright/webkit-${ARTIFACT_REV}/INSTALLATION_COMPLETE
-# Allocator parity with playwright/Dockerfile.alpine's pw_run.sh wrapper, for
-# the same reason as firefox's above: bmalloc backs fastMalloc only, so GLib,
+# Allocator AND libm parity with playwright/Dockerfile.alpine's pw_run.sh
+# wrapper, for the same reason as firefox's above: bmalloc backs fastMalloc
+# only, so GLib,
 # GStreamer, Skia, Cairo, HarfBuzz, ICU, libsoup and fontconfig all allocate
 # through musl's mallocng, and conformance has to exercise the allocator we
 # actually ship. pw_run.sh resolves everything from \$(dirname "\$0"), so it
 # does not care that it was renamed inside its own directory.
+COPY fastfmod /tmp/fastfmod
+RUN apk add --no-cache gcc musl-dev \\
+ && gcc -O2 -fPIC -shared -o /usr/lib/libfastfmod.so /tmp/fastfmod/fastfmod.c \\
+ && apk del gcc musl-dev
 RUN WKRUN=/ms-playwright/webkit-${ARTIFACT_REV}/pw_run.sh \\
  && mv "\$WKRUN" "\$(dirname "\$WKRUN")/pw_run.real.sh" \\
  && printf '%s\\n' \\
       '#!/bin/sh' \\
       'D=\$(dirname "\$0")' \\
-      'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2' \\
+      'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2:/usr/lib/libfastfmod.so' \\
       'exec "\$D/pw_run.real.sh" "\$@"' \\
       > "\$WKRUN" \\
  && chmod +x "\$WKRUN"

--- a/playwright/alpine-browsers/webkit/fastfmod/fastfmod-vectors.c
+++ b/playwright/alpine-browsers/webkit/fastfmod/fastfmod-vectors.c
@@ -1,0 +1,163 @@
+/*
+ * Drives a fixed, deterministic operand stream through whatever `fmod` the
+ * loader bound, and prints a fingerprint of the RAW RESULT BITS.
+ *
+ * The gate runs this twice — once plain, once with libfastfmod.so preloaded —
+ * and diffs the two outputs. Comparing bits rather than values means a
+ * differing signed zero or NaN payload fails; comparing two runs of the SAME
+ * binary means the reference is musl's own fmod rather than anything I wrote.
+ *
+ * Results are folded into 64 buckets so a mismatch localises to a bucket
+ * instead of just saying "different", while the output stays a few hundred
+ * bytes rather than a 50 MB dump.
+ *
+ * MUST be compiled -fno-builtin-fmod. gcc 15 expands fmod inline when the
+ * divisor is a compile-time power of two, and then this program verifies
+ * nothing while still linking `U fmod` from an unrelated call site — which is
+ * exactly how two earlier microbenchmarks of mine "measured" a libc they
+ * never called. run-gate.sh asserts the call count as well.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <stdlib.h>
+
+#define BUCKETS 64
+#define EXP_FIELD 0x7ff0000000000000ULL
+
+static uint64_t bucket[BUCKETS];
+static long checked;
+
+static uint64_t to_bits(double d) {
+  uint64_t u;
+  memcpy(&u, &d, sizeof u);
+  return u;
+}
+
+static double to_double(uint64_t u) {
+  double d;
+  memcpy(&d, &u, sizeof u);
+  return d;
+}
+
+/* FNV-1a over the result bits AND both operands, so a wrong answer cannot be
+ * cancelled out by a different pairing landing in the same bucket. */
+static void record(double a, double b) {
+  uint64_t r = to_bits(fmod(a, b));
+  uint64_t h = bucket[checked % BUCKETS];
+  uint64_t words[3] = {to_bits(a), to_bits(b), r};
+  for (int w = 0; w < 3; w++) {
+    for (int byte = 0; byte < 8; byte++) {
+      h ^= (words[w] >> (byte * 8)) & 0xff;
+      h *= 0x100000001b3ULL;
+    }
+  }
+  bucket[checked % BUCKETS] = h;
+  checked++;
+}
+
+static uint64_t rng = 0x243f6a8885a308d3ULL;
+static uint64_t nextrand(void) {
+  rng ^= rng << 13;
+  rng ^= rng >> 7;
+  rng ^= rng << 17;
+  return rng;
+}
+
+int main(void) {
+  for (int i = 0; i < BUCKETS; i++) {
+    bucket[i] = 0xcbf29ce484222325ULL;
+  }
+
+  /* 1. The runtime probe's own kernel stream, which is the case that made
+   *    this worth doing at all. */
+  for (long i = 1; i < 300000; i++) {
+    record((double)i * 2654435761.0, 4294967296.0);
+  }
+
+  /* 2. Every corner, at both signs. Zero divisor, both infinities, NaN, the
+   *    smallest normal, subnormals down to DBL_TRUE_MIN, exact multiples. */
+  static const double edges[] = {
+      0.0,
+      1.0,
+      0.5,
+      2.0,
+      3.0,
+      1024.25,
+      4294967296.0,
+      9007199254740992.0,
+      1e308,
+      2.2250738585072014e-308, /* DBL_MIN, smallest normal */
+      1.1125369292536007e-308, /* half of it: subnormal */
+      4.9406564584124654e-324, /* DBL_TRUE_MIN */
+      1.5e-323,
+      7.4e-323,
+      INFINITY,
+      NAN,
+  };
+  const int nedges = (int)(sizeof edges / sizeof *edges);
+  for (int a = 0; a < nedges; a++) {
+    for (int b = 0; b < nedges; b++) {
+      for (int sa = 0; sa < 2; sa++) {
+        for (int sb = 0; sb < 2; sb++) {
+          record(sa ? -edges[a] : edges[a], sb ? -edges[b] : edges[b]);
+        }
+      }
+    }
+  }
+
+  /* 3. Unrestricted random bit patterns: every class, in proportion. */
+  for (long i = 0; i < 4000000; i++) {
+    record(to_double(nextrand()), to_double(nextrand()));
+  }
+
+  /* 4. Subnormal-heavy: exponent fields forced into [0,3] on one or both
+   *    sides, since class 3 only reaches a subnormal about 1 time in 2048. */
+  for (long i = 0; i < 800000; i++) {
+    uint64_t a = (nextrand() & ~EXP_FIELD) | ((uint64_t)(nextrand() % 4) << 52);
+    uint64_t b = (nextrand() & ~EXP_FIELD) | ((uint64_t)(nextrand() % 4) << 52);
+    record(to_double(a), to_double(b));
+  }
+
+  /* 5. Large exponent gaps, which is the path the cmov loop actually changes:
+   *    a big dividend against a modest divisor, at both signs. */
+  for (long i = 0; i < 1200000; i++) {
+    double a = (double)(int64_t)(nextrand() >> 11);
+    double b = (double)(uint32_t)nextrand() + 1.0;
+    record(a, b);
+    record(-a, b);
+  }
+
+  printf("checked=%ld\n", checked);
+  for (int i = 0; i < BUCKETS; i++) {
+    printf("bucket%02d=%016llx\n", i, (unsigned long long)bucket[i]);
+  }
+
+  /* Timing is informational and the gate does not fail on it. Reported so a
+   * build that silently loses the speedup is still visible in the log, and
+   * opt-in so the gate's two verification-only runs — the call counter and
+   * the corrupted control — do not pay for 15M extra calls each. */
+  if (!getenv("FASTFMOD_TIMING")) {
+    return 0;
+  }
+  double best = 1e18;
+  volatile double sink = 0;
+  for (int r = 0; r < 5; r++) {
+    struct timespec t0, t1;
+    double s = 0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (long i = 1; i < 3000000; i++) {
+      s += fmod((double)i * 2654435761.0, 4294967296.0);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    sink = s;
+    double ms = (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) / 1e6;
+    if (ms < best) {
+      best = ms;
+    }
+  }
+  fprintf(stderr, "kernel_best_ms=%.1f checksum=%.0f\n", best, sink);
+  return 0;
+}

--- a/playwright/alpine-browsers/webkit/fastfmod/fastfmod.c
+++ b/playwright/alpine-browsers/webkit/fastfmod/fastfmod.c
@@ -1,0 +1,135 @@
+/*
+ * A drop-in `fmod` for musl, preloaded under WebKit.
+ *
+ * Why: `libm_fmod` is the largest single per-metric gap we have on any
+ * browser — 5.35x against official on an EPYC 7763, 6.3x on an EPYC 9V74,
+ * 7.65x on a Xeon 8370C. It is not JSC. Both engines call libc the same
+ * 3,000,000 times per kernel invocation (interposed and counted:
+ * 30,000,033 ours vs 30,000,057 official), the per-call engine overhead is
+ * identical, and the gap appears only when the dividend is large relative to
+ * the divisor. Isolated and gated, glibc answers in 54.0 ms per 3M calls and
+ * musl in 163.8 ms.
+ *
+ * The mechanism is musl's loop: it walks the exponent difference one bit per
+ * iteration with a data-dependent branch in the body, so for operands like
+ * the probe's (~21 bits of difference) every call eats ~21 unpredictable
+ * branches. Replacing that branch with a conditional move is the whole fix;
+ * the arithmetic is unchanged, which is why the result is bit-identical.
+ *
+ * SELF-CONTAINED ON PURPOSE. An earlier prototype deferred NaN/inf/subnormal
+ * corners to `fmod()`. That is fine for a normal function and catastrophic
+ * for an interposer: once this object exports `fmod`, that call resolves back
+ * here and recurses forever. There is deliberately no dlsym, no RTLD_NEXT and
+ * no fallback path — every case is handled below.
+ *
+ * Correctness is not asserted, it is gated: fastfmod-vectors.c runs the same
+ * operand stream with and without this object preloaded and compares the raw
+ * result BITS, so a differing signed zero or NaN payload fails the build.
+ * See run-gate.sh.
+ */
+#include <stdint.h>
+#include <string.h>
+
+#define MANT_MASK 0x000fffffffffffffULL
+#define IMPLICIT  0x0010000000000000ULL
+#define SIGN_BIT  0x8000000000000000ULL
+#define EXP_MASK  0x7ffULL
+
+static inline uint64_t to_bits(double d) {
+  uint64_t u;
+  memcpy(&u, &d, sizeof u);
+  return u;
+}
+
+static inline double to_double(uint64_t u) {
+  double d;
+  memcpy(&d, &u, sizeof u);
+  return d;
+}
+
+/* Bring a subnormal significand up so bit 52 is set, returning the exponent
+ * it then corresponds to. Mirrors what the hardware would have stored had the
+ * value been normal. */
+static inline int normalise(uint64_t *sig) {
+  int shift = 0;
+  while ((*sig & IMPLICIT) == 0) {
+    *sig <<= 1;
+    shift++;
+  }
+  return 1 - shift;
+}
+
+double fmod(double x, double y) {
+  uint64_t ux = to_bits(x);
+  uint64_t uy = to_bits(y);
+  uint64_t sign = ux & SIGN_BIT;
+  int ex = (int)(ux >> 52 & EXP_MASK);
+  int ey = (int)(uy >> 52 & EXP_MASK);
+
+  /* NaN operand: propagate the FIRST one, sign and payload included, which is
+   * what musl does. `x + y` gets this for free from SSE's source-operand rule.
+   * Worth its own branch: the arithmetic NaN below returns the wrong SIGN for
+   * fmod(NaN, -NaN) and fmod(-NaN, NaN), which is 2 cases in 1024 and was
+   * caught by the bit-comparison gate rather than by reading the code. */
+  if (x != x || y != y) {
+    return x + y;
+  }
+  /* Infinite dividend or zero divisor: domain error, quiet NaN. Produced
+   * arithmetically so FE_INVALID is raised the way libm raises it, rather
+   * than by returning a hand-built payload. */
+  if (ex == 0x7ff || (uy << 1) == 0) {
+    return (x * y) / (x * y);
+  }
+  /* Finite dividend, infinite divisor: the dividend is the remainder. */
+  if (ey == 0x7ff) {
+    return x;
+  }
+  /* |x| < |y| leaves x untouched; |x| == |y| divides exactly. */
+  if ((ux << 1) < (uy << 1)) {
+    return x;
+  }
+  if ((ux << 1) == (uy << 1)) {
+    return to_double(sign);
+  }
+
+  uint64_t i = ux & MANT_MASK;
+  uint64_t m = uy & MANT_MASK;
+  if (ex == 0) {
+    ex = normalise(&i);
+  } else {
+    i |= IMPLICIT;
+  }
+  if (ey == 0) {
+    ey = normalise(&m);
+  } else {
+    m |= IMPLICIT;
+  }
+
+  /* The hot loop, and the entire point of this file. `i` is committed with a
+   * conditional move, never a branch. Letting `i` reach zero is safe: 0 - m
+   * stays negative forever after, so the cmov holds it at zero and the shifts
+   * keep it there — which is why the zero test lives after the loop and not
+   * inside it, where it would put the branch straight back. */
+  for (; ex > ey; ex--) {
+    uint64_t r = i - m;
+    i = (r >> 63) ? i : r;
+    i <<= 1;
+  }
+  uint64_t r = i - m;
+  i = (r >> 63) ? i : r;
+
+  if (i == 0) {
+    return to_double(sign);
+  }
+  while ((i & IMPLICIT) == 0) {
+    i <<= 1;
+    ex--;
+  }
+  /* A remainder can land below the normal range even when both operands are
+   * normal, so denormalise rather than emitting a bogus exponent. */
+  if (ex <= 0) {
+    i >>= 1 - ex;
+    return to_double(sign | i);
+  }
+  return to_double(sign | ((uint64_t)ex << 52) | (i & MANT_MASK));
+}

--- a/playwright/alpine-browsers/webkit/fastfmod/fmod-call-counter.c
+++ b/playwright/alpine-browsers/webkit/fastfmod/fmod-call-counter.c
@@ -1,0 +1,54 @@
+/*
+ * Counts calls that actually reach libc's `fmod`. This exists because a
+ * verification run that never calls fmod passes trivially, and looks exactly
+ * like a run that passed for real.
+ *
+ * gcc 15 expands `fmod` inline when the divisor is a compile-time power of
+ * two. Under that expansion a microbenchmark reports plausible timings and a
+ * differential test reports zero mismatches, while libc is never entered —
+ * and `nm -D` still shows `U fmod` from some unrelated call site, so the
+ * obvious check confirms a call the hot loop never makes. Two of my own
+ * benchmarks did precisely this before it was caught.
+ *
+ * run-gate.sh preloads this and requires a minimum call count before it will
+ * accept the verification as meaningful.
+ *
+ * Do NOT use this to time anything: the two clock_gettime calls cost roughly
+ * 65 ns per invocation and swamp the effect under measurement. The count is
+ * the trustworthy output.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static double (*real_fmod)(double, double);
+static unsigned long long calls;
+
+__attribute__((constructor)) static void init(void) {
+  real_fmod = (double (*)(double, double))dlsym(RTLD_NEXT, "fmod");
+}
+
+__attribute__((destructor)) static void dump(void) {
+  const char *out = getenv("FMOD_COUNT_OUT");
+  if (!out) {
+    return;
+  }
+  char path[512];
+  snprintf(path, sizeof path, "%s.%d", out, (int)getpid());
+  FILE *f = fopen(path, "w");
+  if (!f) {
+    return;
+  }
+  fprintf(f, "%llu\n", calls);
+  fclose(f);
+}
+
+double fmod(double x, double y) {
+  if (!real_fmod) {
+    real_fmod = (double (*)(double, double))dlsym(RTLD_NEXT, "fmod");
+  }
+  calls++;
+  return real_fmod(x, y);
+}

--- a/playwright/alpine-browsers/webkit/fastfmod/run-gate.sh
+++ b/playwright/alpine-browsers/webkit/fastfmod/run-gate.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Proves libfastfmod.so returns bit-identical results to musl's own fmod.
+#
+# Method: build ONE vectors binary, run it twice — plain, then with the
+# preload — and diff the outputs. The reference is therefore musl itself
+# rather than a second implementation of mine, and the subject is the actual
+# shipped .so rather than the same code linked differently.
+#
+# Three things this gate refuses to accept:
+#   1. a run where fmod was never actually called (gcc inlines it on a
+#      power-of-two divisor, and then everything passes vacuously);
+#   2. a preloaded run that did not load the preload (ld.so only WARNS on a
+#      missing preload and carries on, which would silently compare musl
+#      against musl and pass);
+#   3. itself, unless a deliberately corrupted build makes it fail.
+#
+# Usage: run-gate.sh [srcdir] [outdir]
+set -eu
+
+SRC="${1:-$(dirname "$0")}"
+OUT="${2:-/tmp/fastfmod-gate}"
+CC="${CC:-gcc}"
+# The vectors binary makes exactly 7,501,023 fmod calls in its
+# verification classes; the counter run skips the timing loop, so this
+# floor sits just under that and any inlining drops it to ~0.
+MIN_CALLS=7500000
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+echo "===== build ====="
+# -fno-builtin-fmod on the vectors binary is load-bearing; see the file header.
+$CC -O2 -fno-builtin-fmod -o "$OUT/vectors" "$SRC/fastfmod-vectors.c" -lm
+$CC -O2 -fPIC -shared -o "$OUT/libfastfmod.so" "$SRC/fastfmod.c"
+$CC -O2 -fPIC -shared -o "$OUT/libcounter.so" "$SRC/fmod-call-counter.c" -ldl
+# The corrupted twin: the cmov's two arms swapped. Derived from the same
+# source so it cannot drift away from the real one, and it must fail step 5.
+sed 's/i = (r >> 63) ? i : r;/i = (r >> 63) ? r : i;/' "$SRC/fastfmod.c" > "$OUT/broken.c"
+if cmp -s "$SRC/fastfmod.c" "$OUT/broken.c"; then
+  echo "FAIL: the corruption did not apply — the negative control would be vacuous" >&2
+  exit 1
+fi
+$CC -O2 -fPIC -shared -o "$OUT/libbroken.so" "$OUT/broken.c"
+
+echo "===== 1. non-vacuity: fmod must really be called ====="
+rm -f "$OUT"/count.*
+FMOD_COUNT_OUT="$OUT/count" LD_PRELOAD="$OUT/libcounter.so" "$OUT/vectors" >/dev/null 2>&1
+CALLS=$(cat "$OUT"/count.* 2>/dev/null || echo 0)
+echo "libc fmod calls observed: $CALLS (minimum $MIN_CALLS)"
+if [ "$CALLS" -lt "$MIN_CALLS" ]; then
+  echo "FAIL: fmod was inlined away — this run verifies nothing" >&2
+  exit 1
+fi
+
+echo "===== 2. reference run (musl) ====="
+FASTFMOD_TIMING=1 "$OUT/vectors" > "$OUT/reference.txt" 2> "$OUT/reference.time"
+echo "$(head -1 "$OUT/reference.txt")  $(cat "$OUT/reference.time")"
+
+echo "===== 3. subject run (libfastfmod.so preloaded) ====="
+# ld.so only warns on an unloadable preload, so prove it loaded rather than
+# trusting the variable: the process must map it.
+LD_PRELOAD="$OUT/libfastfmod.so" sh -c 'grep -q libfastfmod /proc/self/maps' \
+  || { echo "FAIL: libfastfmod.so did not load" >&2; exit 1; }
+FASTFMOD_TIMING=1 LD_PRELOAD="$OUT/libfastfmod.so" "$OUT/vectors" > "$OUT/subject.txt" 2> "$OUT/subject.time"
+echo "$(head -1 "$OUT/subject.txt")  $(cat "$OUT/subject.time")"
+
+echo "===== 4. bit-exactness ====="
+if ! diff -u "$OUT/reference.txt" "$OUT/subject.txt" > "$OUT/diff.txt"; then
+  echo "FAIL: libfastfmod.so is not bit-identical to musl's fmod" >&2
+  head -40 "$OUT/diff.txt" >&2
+  exit 1
+fi
+echo "PASS: $(head -1 "$OUT/subject.txt") comparisons, all 64 bucket digests identical"
+
+echo "===== 5. negative control: the gate must reject a broken build ====="
+# Bounded: a corrupted fmod can spin forever rather than answer wrongly (this
+# one does — the normalisation loop shifts a zeroed significand for ever), and
+# a hang is a rejection too, just one that has to be caught rather than waited
+# on. Only byte-identical output means the comparison has no teeth.
+: > "$OUT/broken.txt"
+# `|| BROKEN_RC=$?` rather than a bare call then `$?`: under `set -e` the
+# non-zero exit aborts the script before the assignment is ever reached, and
+# the gate then fails with the control's own rc instead of judging it.
+BROKEN_RC=0
+timeout 90 env LD_PRELOAD="$OUT/libbroken.so" "$OUT/vectors" \
+  > "$OUT/broken.txt" 2>/dev/null || BROKEN_RC=$?
+if [ "$BROKEN_RC" -eq 124 ] || [ "$BROKEN_RC" -eq 137 ]; then
+  echo "PASS: corrupted build did not terminate — rejected"
+elif diff -q "$OUT/reference.txt" "$OUT/broken.txt" >/dev/null 2>&1; then
+  echo "FAIL: a deliberately corrupted fmod passed — this gate proves nothing" >&2
+  exit 1
+else
+  echo "PASS: corrupted build produced different digests — rejected"
+fi
+
+echo "===== gate green ====="


### PR DESCRIPTION
#123 merged while this was in review, so this now targets main directly and the diff is fmod-only: one more entry in the `pw_run.sh` `LD_PRELOAD` that PR added, plus the object and its gate. Rebased with `--onto` rather than merged, so nothing from #123 is duplicated here — the 3-dot diff is byte-identical to what it was before the retarget. Full background in #126.

`libm_fmod` is the largest single per-metric gap on any of our browsers: **5.35x** against official on an EPYC 7763, **6.31x** on an EPYC 9V74, **7.65x** on a Xeon 8370C. It is musl's `fmod`, and the thing I want on the record is that it is *not* JSC — I assumed it was, twice, and both times was wrong.

| evidence | reading |
|---|---|
| `(i*2654435761) % 4294967296` — the probe's kernel | ours 184 ms / official 70 ms — **2.63x** |
| `(i*1.5) % 1024.25` — the same `fmod` call, small magnitudes | 58 / 54 — **1.07x** |
| `(i*7) % 65536` — stays int32, never reaches libm | 8 / 9 |
| `Math.sqrt(i)` — inlined SSE, a JIT-is-healthy control | 7 / 7 |
| calls into libc, interposed and counted | **30,000,033** ours vs **30,000,057** official |
| isolated per 3M calls, with a call-count gate | glibc **54.0 ms**, musl **163.8 ms** |

Same call count, identical per-call engine overhead, healthy JIT, and the gap appears only once the dividend is large relative to the divisor. musl walks the exponent difference one bit at a time with a data-dependent branch in the loop body, so the probe's operands (~21 bits of difference) pay ~21 unpredictable branches per call. Swapping that branch for a conditional move is the whole change — the arithmetic is untouched, which is exactly why the result is bit-identical. On alpine:edge it takes the kernel from **289.6 ms to 122.7 ms**.

## Scope: what this interposes, and what happens when it fails

It replaces `fmod` for `MiniBrowser` and every WebKit auxiliary process, and for nothing else — not the Node driver, not chromium, not firefox. `LD_PRELOAD` failure is non-fatal by design: ld.so warns on stderr and continues, so a missing or unloadable object leaves WebKit **correct** and merely as slow as it is today. Nothing depends on the preload succeeding for correctness.

It is deliberately self-contained — no dlsym, no `RTLD_NEXT`, no fallback path. My prototype deferred the NaN and subnormal corners to `fmod()`, which is fine in an ordinary function and is infinite recursion in an interposer the moment the object exports that symbol. Worth flagging since the prototype is what you approved.

## The gate

Replacing a libm function underneath a browser is a correctness surface, so the differential is in CI where it re-runs rather than in a transcript. `run-gate.sh` builds one vectors binary, runs it with and without the preload, and compares **raw result bits** over **7,501,023** operand pairs: the probe's own stream, the full edge table at both signs (signed zeros, both infinities, NaN, zero divisor, `DBL_MIN`, subnormals down to `DBL_TRUE_MIN`, exact multiples), unrestricted random bit patterns, a subnormal-heavy class, and a large-exponent-gap class. Bits rather than values, so a differing signed zero or NaN payload fails.

Three things it refuses to accept:

1. **A run where `fmod` was never called.** gcc 15 expands it inline on a compile-time power-of-two divisor, and the whole comparison then passes vacuously while `nm -D` still reports `U fmod` from an unrelated call site. Two of my own benchmarks did precisely this. Hence `-fno-builtin-fmod` plus a preloaded counter that must observe ≥7,500,000 real calls.
2. **A preloaded run that did not load the preload.** ld.so only warns, so the run would compare musl against musl and pass; the gate greps `/proc/self/maps`.
3. **Itself.** A corrupted twin generated from this same source with the cmov's arms swapped must fail — either by disagreeing or by not terminating, which is what it actually does on some builds, so both outcomes are handled.

**The gate caught a real bug on its first run**, which is the best argument for it existing. It failed on 3 of 64 bucket digests; that localised to 2 of 1024 edge cases — `fmod(NaN, -NaN)` and `fmod(-NaN, NaN)` — where musl propagates the first NaN operand's *sign* and my arithmetic `(x*y)/(x*y)` did not. Nobody finds that by reading the code.

The conformance runner gets the same preload, for the reason it already carries the allocator one: a suite running a different libm than the image ships is validating a build nobody runs.

## Verified before asking for review

Gate green end-to-end on `alpine:edge` (the base the workflow uses): 7,501,023 comparisons, all 64 digests identical, 7,501,023 real libc calls observed, corrupted control rejected. The `fastfmod-build` stage builds and its smoke passes against a real `docker build --target`.

## Open questions

- **Upstream?** This belongs in musl more than it belongs in our image, and firefox would benefit for free. I have not sent it — say the word and I will, with the differential harness attached.
- **Should firefox take it too?** Its `libm_fmod` reads *faster* than official, so it is not paying this cost and I left it alone. Adding it would be speculative.
- **`(x*y)/(x*y)`** for the invalid cases raises `FE_INVALID` arithmetically rather than returning a hand-built payload. I believe that is the right call over hardcoding a NaN, but it is a judgement and the gate only proves the *result* matches, not the flag.

## Correction carried over from #126

An earlier revision of #126 leaned on the compiler-folding story more heavily than the evidence supports. The folding is a fact about **my C microbenchmarks**, not about the browsers, and the coordinator refuted it as an explanation for the cross-browser spread (swapping the divisor for a prime moves V8's kernel 3%, not 3x). Firefox reading ~0.67 on this metric remains **unexplained** and is not addressed here; #126 now says so.
