### PR TITLE
perf(webkit): pin mimalloc's purge — EXPERIMENT for the goto_warm regression

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -184,12 +184,24 @@ RUN sudo touch /ms-playwright/webkit-${WK_REV}/INSTALLATION_COMPLETE \
 # warns on stderr and continues: WebKit still runs and still returns correct
 # results, just at musl's allocator and musl's fmod speed. There is no
 # correctness dependency on the preload succeeding.
+# EXPERIMENT (perf/webkit-mimalloc-purge): MIMALLOC_PURGE_DELAY=-1 never
+# returns freed pages to the OS. `goto_warm` is the one metric the allocator
+# preload made WORSE (1.17-1.20 -> 1.23-1.39 across three same-CPU pairings)
+# and it is now shipped, so it needs an explanation or a fix.
+#
+# Note the leading hypothesis is already WEAK: if purging were the mechanism
+# the next navigation would re-fault the pages, and measured over 40 warm
+# navigations mimalloc takes FEWER minor faults than musl (201/nav vs 381) and
+# zero major faults vs 12. So this arm is expected to be flat, and a flat
+# result is the useful outcome — it retires the last mechanism I have and
+# leaves "goto_warm cannot resolve 4 ms" as the explanation.
 RUN sudo mv /ms-playwright/webkit-${WK_REV}/pw_run.sh \
             /ms-playwright/webkit-${WK_REV}/pw_run.real.sh \
  && printf '%s\n' \
         '#!/bin/sh' \
         'DIR="$(dirname "$0")"' \
         'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2:/usr/lib/libfastfmod.so' \
+        'export MIMALLOC_PURGE_DELAY=-1' \
         'exec "$DIR/pw_run.real.sh" "$@"' \
   | sudo tee /ms-playwright/webkit-${WK_REV}/pw_run.sh >/dev/null \
  && sudo chmod +x /ms-playwright/webkit-${WK_REV}/pw_run.sh


### PR DESCRIPTION
**Experiment, not a merge request.** It exists to build an image so `perf-probe` can measure it; I will report the number and close it if flat.

`goto_warm` is the one metric the allocator preload made worse — 1.17-1.20 → 1.23-1.39 across three same-CPU pairings — and #123 shipped it, so it is a live regression on users rather than a footnote on a branch. `MIMALLOC_PURGE_DELAY=-1` stops mimalloc returning freed pages to the OS, which is the last mechanism I have.

**I expect this to be flat, and I want that on the record before the number arrives.** If purging were the cause, the next navigation would re-fault those pages. Measured over 40 warm navigations in WPEWebProcess:

| | baseline | mimalloc |
|---|---|---|
| minor faults | 15,236 (381/nav) | **8,059 (201/nav)** |
| major faults | 12 | **0** |
| RSS before → after | 271 → 328 MB | 258 → **321 MB** |

The fault count moves the *wrong way* for the theory, and RSS is already exonerated. A flat arm is still worth the run: it retires the mechanism and leaves the likeliest explanation being that `goto_warm` cannot resolve the effect — it is ~24 ms absolute, the three pairings disagree among themselves by an order of magnitude, and it is the one metric whose null arm sits at 1.11-1.12 while every other null metric reads 1.00.

Open question if it *is* flat: do we keep chasing a 4 ms row, or does `goto_warm` need rescaling the way #129 rescaled the in-page kernels? I lean toward the latter — a metric that cannot resolve its own effect size will keep generating false regressions for whoever touches the allocator next.