### PR TITLE
perf(webkit): a load probe for launch, on a machine that can resolve it

### DIFF
--- a/.github/workflows/wk-load-probe.yml
+++ b/.github/workflows/wk-load-probe.yml
@@ -1,0 +1,128 @@
+name: WebKit load probe
+
+# `launch` is WebKit's largest remaining gap (1.37x official) and it did not
+# move with the allocator. Two candidates are already dead, both by
+# measurement: the DSO closure (ours carries 60 DT_NEEDED against official's
+# 70 — ours is the LEANER side, so chromium's explanation does not transfer)
+# and BIND_NOW (a within-binary RTLD_NOW/RTLD_LAZY A/B on official showed no
+# cost for eager binding).
+#
+# What is left is that ours has FEWER relocations and a SMALLER .text yet
+# appeared to dlopen slower — which points at musl's dynamic loader rather
+# than at anything in our build. That reading came off a loaded laptop where
+# official's spread was 55.8-133 ms, so it is a lead and not a finding. This
+# workflow re-takes it on a quiet runner, with both libraries measured in the
+# SAME job so the machine divides out — the same reason perf-probe interleaves
+# its arms.
+
+on:
+  pull_request:
+    paths:
+      - 'playwright/alpine-browsers/webkit/loadprobe/**'
+      - '.github/workflows/wk-load-probe.yml'
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Our image to measure'
+        default: 'ghcr.io/jclaveau/alpine-dood-playwright:latest'
+        type: string
+      pw_version:
+        description: 'PW version, for the official control tag'
+        default: '1.62.1'
+        type: string
+      wk_rev:
+        description: 'WebKit revision, for the cache-path layout'
+        default: '2336'
+        type: string
+
+concurrency:
+  group: wk-load-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Record the runner
+        # The alpine/official ratio is CPU-dependent, so the model belongs in
+        # the log even though both arms here share one machine.
+        run: |
+          grep -m1 'model name' /proc/cpuinfo
+          nproc
+
+      - name: Ours (musl)
+        env:
+          OURS: ${{ inputs.image || 'ghcr.io/jclaveau/alpine-dood-playwright:latest' }}
+          REV: ${{ inputs.wk_rev || '2336' }}
+        run: |
+          set -o pipefail
+          docker run --rm --security-opt seccomp=unconfined \
+            -v "$PWD/playwright/alpine-browsers/webkit/loadprobe:/probe:ro" \
+            --entrypoint sh "$OURS" -c '
+              sudo apk add --no-cache gcc musl-dev binutils >/dev/null 2>&1
+              gcc -O2 -o /tmp/loadbench /probe/loadbench.c
+              sh /probe/run-load-probe.sh \
+                 "/ms-playwright/webkit-'"$REV"'/minibrowser-wpe/libWPEWebKit-2.0.so.1" 12
+            ' 2>&1 | tee ours.txt
+
+      - name: Official (glibc)
+        env:
+          PW: ${{ inputs.pw_version || '1.62.1' }}
+          REV: ${{ inputs.wk_rev || '2336' }}
+        run: |
+          set -o pipefail
+          # Official's layout is bin/ + lib/ + sys/lib/, not our flat one, so
+          # its peer libraries need an explicit search path or dlopen fails
+          # with a missing libwpe / libbacktrace rather than a slow load.
+          docker run --rm --security-opt seccomp=unconfined \
+            -v "$PWD/playwright/alpine-browsers/webkit/loadprobe:/probe:ro" \
+            --entrypoint sh "mcr.microsoft.com/playwright:v${PW}-noble" -c '
+              (apt-get -qq update && apt-get -qq install -y gcc binutils) >/dev/null 2>&1
+              gcc -O2 -o /tmp/loadbench /probe/loadbench.c -ldl
+              D=/ms-playwright/webkit-'"$REV"'/minibrowser-wpe
+              export LD_LIBRARY_PATH="$D/lib:$D/sys/lib"
+              sh /probe/run-load-probe.sh "$D/lib/libWPEWebKit-2.0.so.1" 12
+            ' 2>&1 | tee official.txt
+
+      - name: Best-of summary
+        if: always()
+        run: |
+          set -eu
+          # A failed dlopen prints FAILED and no timing; awk over an empty set
+          # would report "inf" and look like a result, so assert we have rows.
+          summarise() {
+            n=$(grep -cE '^(LAZY|NOW)' "$1" || true)
+            if [ "$n" -lt 4 ]; then
+              echo "$2: only $n timed loads — probe did not run, not a measurement"
+              return
+            fi
+            for mode in LAZY NOW; do
+              best=$(awk -v m="$mode" '$1==m {print $2}' "$1" | sort -n | head -1)
+              echo "$2 $mode best-of-12: ${best} ms"
+            done
+          }
+          summarise ours.txt "ours    "
+          summarise official.txt "official"
+          {
+            echo '### WebKit load probe'
+            echo '```'
+            summarise ours.txt "ours    "
+            summarise official.txt "official"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wk-load-probe
+          path: '*.txt'
+          if-no-files-found: warn

--- a/.github/workflows/wk-load-probe.yml
+++ b/.github/workflows/wk-load-probe.yml
@@ -23,8 +23,12 @@ on:
   workflow_dispatch:
     inputs:
       image:
+        # `edge` and not `latest`: GHCR has NO `latest` for this image — only
+        # Docker Hub does — and a default that does not resolve fails the
+        # probe with `manifest unknown`, which is how this workflow's first
+        # run died.
         description: 'Our image to measure'
-        default: 'ghcr.io/jclaveau/alpine-dood-playwright:latest'
+        default: 'ghcr.io/jclaveau/alpine-dood-playwright:edge'
         type: string
       pw_version:
         description: 'PW version, for the official control tag'
@@ -61,7 +65,7 @@ jobs:
 
       - name: Ours (musl)
         env:
-          OURS: ${{ inputs.image || 'ghcr.io/jclaveau/alpine-dood-playwright:latest' }}
+          OURS: ${{ inputs.image || 'ghcr.io/jclaveau/alpine-dood-playwright:edge' }}
           REV: ${{ inputs.wk_rev || '2336' }}
         run: |
           set -o pipefail
@@ -75,6 +79,10 @@ jobs:
             ' 2>&1 | tee ours.txt
 
       - name: Official (glibc)
+        # One arm failing must not cost us the other's measurement — the same
+        # reason perf-probe records a failure and carries on through its target
+        # loop. The summary step decides what is and is not a measurement.
+        if: always()
         env:
           PW: ${{ inputs.pw_version || '1.62.1' }}
           REV: ${{ inputs.wk_rev || '2336' }}
@@ -100,8 +108,16 @@ jobs:
           # A failed dlopen prints FAILED and no timing; awk over an empty set
           # would report "inf" and look like a result, so assert we have rows.
           summarise() {
+            # A missing file means the arm's docker step never produced output
+            # at all; without this the count is empty, the -lt test is a syntax
+            # error, and the function prints an empty best-of that reads like a
+            # measurement. That is exactly what the first run did.
+            if [ ! -f "$1" ]; then
+              echo "$2: no output file — arm did not run, not a measurement"
+              return
+            fi
             n=$(grep -cE '^(LAZY|NOW)' "$1" || true)
-            if [ "$n" -lt 4 ]; then
+            if [ -z "$n" ] || [ "$n" -lt 4 ]; then
               echo "$2: only $n timed loads — probe did not run, not a measurement"
               return
             fi

--- a/playwright/alpine-browsers/webkit/loadprobe/loadbench.c
+++ b/playwright/alpine-browsers/webkit/loadprobe/loadbench.c
@@ -1,0 +1,37 @@
+/*
+ * Times what `launch` mostly is: mapping libWPEWebKit and processing its
+ * ~320,000 relocations. RTLD_NOW vs RTLD_LAZY is the same distinction as the
+ * BIND_NOW flag ours links and official's does not, tested inside one process
+ * so nothing else varies.
+ *
+ * Prints a non-vacuity witness (the resolved address of a known symbol), since
+ * a dlopen that silently failed would otherwise report a very fast load.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+
+static double now_ms(void) {
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return t.tv_sec * 1e3 + t.tv_nsec / 1e6;
+}
+
+int main(int argc, char **argv) {
+  const char *path = argv[1];
+  int mode = (argc > 2 && argv[2][0] == 'n') ? RTLD_NOW : RTLD_LAZY;
+
+  double t0 = now_ms();
+  void *h = dlopen(path, mode);
+  double t1 = now_ms();
+  if (!h) {
+    printf("FAILED: %s\n", dlerror());
+    return 1;
+  }
+  void *sym = dlsym(h, "wpe_view_backend_create");
+  printf("%-5s %8.1f ms   witness=%s\n", mode == RTLD_NOW ? "NOW" : "LAZY", t1 - t0,
+         sym ? "resolved" : "MISSING");
+  return sym ? 0 : 2;
+}

--- a/playwright/alpine-browsers/webkit/loadprobe/run-load-probe.sh
+++ b/playwright/alpine-browsers/webkit/loadprobe/run-load-probe.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Times what `launch` mostly is: mapping libWPEWebKit and processing its
+# ~320,000 relocations. Run against ONE library path; the workflow runs it in
+# our image and in the official one on the SAME runner so the two are
+# comparable.
+#
+# Why this probe exists: `launch` is 1.37x official and did not move with the
+# allocator. Two candidates are already dead — the DSO closure (ours 60
+# DT_NEEDED against official's 70, so ours is the leaner side) and BIND_NOW
+# (a within-binary RTLD_NOW/RTLD_LAZY A/B on official showed no cost). Ours
+# also has FEWER relocations (320,694 vs 339,342) and a SMALLER .text, and
+# still appeared to load slower on a laptop. That points at musl's dynamic
+# loader rather than at our build, and it needs a quiet machine to confirm.
+set -eu
+
+LIB="${1:?usage: run-load-probe.sh <libWPEWebKit path> [reps]}"
+REPS="${2:-12}"
+BIN="${LOADBENCH:-/tmp/loadbench}"
+
+echo "===== $LIB"
+[ -f "$LIB" ] || { echo "FAIL: no such library" >&2; exit 1; }
+
+# Static shape first — the numbers that make the timing interpretable.
+if command -v readelf >/dev/null 2>&1; then
+  echo "  DT_NEEDED:    $(readelf -d "$LIB" | grep -c NEEDED)"
+  echo "  relocations:  $(readelf -r "$LIB" 2>/dev/null | grep -c '^[0-9a-f]')"
+  echo "  bind-now:     $(readelf -d "$LIB" | grep -cE 'BIND_NOW|Flags: NOW')"
+  echo "  .text bytes:  $(readelf -S -W "$LIB" | awk '$2==".text"{print $6}')"
+fi
+
+# Alternate the modes rather than blocking them, so a machine that drifts
+# part-way through cannot land entirely on one. A load is a floor
+# measurement — noise only ever adds — so the best of each is the number.
+i=0
+while [ "$i" -lt "$REPS" ]; do
+  "$BIN" "$LIB" lazy
+  "$BIN" "$LIB" now
+  i=$((i + 1))
+done


### PR DESCRIPTION
`launch` is WebKit's largest remaining gap (1.37x official) and it did not move with the allocator. This adds the instrument; opening the PR runs it.

**Two candidates are already dead, both by measurement rather than argument:**

- **The DSO closure**, which is what explains chromium's launch gap. It does not transfer — ours carries **60** `DT_NEEDED` against official's **70**, and their `MiniBrowser` has 74. Ours is the leaner side.
- **`BIND_NOW`**, which ours links and official does not. A within-binary `RTLD_NOW` vs `RTLD_LAZY` A/B on *official* — holding every build difference fixed — showed no cost for eager binding. Note `RTLD_LAZY` is inert on our library: `DF_1_NOW` in the object overrides the dlopen flag, so ours cannot be A/B'd that way at all.

**What is left is odd enough to deserve a real machine.** Ours has *fewer* relocations (320,694 vs 339,342) and a *smaller* `.text`, and still appeared to `dlopen` slower — ~84 ms against ~56. By both static measures ours should win. That points at musl's dynamic loader rather than at anything we build, which would make `launch` structural rather than a flag away.

I am not willing to call that from my laptop, where official's own spread was 55.8–133 ms. Hence the probe: both libraries in one job so the machine divides out, best-of-12 with the modes alternated rather than blocked.

**Two guards worth pointing at**, because the naive version of this probe lies:

- The summary refuses to print a best-of when fewer than four timed loads came back. A failed `dlopen` prints `FAILED` and no rows, and an `awk` over nothing yields a number that reads like a result. This already bit me — official's split `bin/` + `lib/` + `sys/lib/` layout needs an explicit `LD_LIBRARY_PATH` or it dies on `libwpe`, then on `libbacktrace`.
- `loadbench.c` resolves a known symbol after the load and prints whether it resolved, so a silently-empty load cannot report a very fast time.

Also ours-only and worth someone's attention separately: `USE_LIBBACKTRACE=OFF` here while official ships `libbacktrace.so.0`, and our flat `RPATH=$ORIGIN` layout against their three-directory split.

Merge-worthy on its own if you want the instrument kept; if you would rather it stayed a throwaway, say so and I will close it once it has produced the number.