### PR TITLE
perf(image): give the playwright driver mimalloc, and keep chromium off it

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -68,6 +68,7 @@ RUN sudo apk add --no-cache \
         libdrm libevent libffi libjpeg-turbo libnotify libogg libtheora \
         libvorbis libvpx libwebp libwebpdemux libxcomposite libxt mesa-gl \
         nspr nss pipewire-libs libpulse libstdc++ libgcc mimalloc2-insecure \
+        mimalloc2 \
         libwpe libwpebackend-fdo gtk4.0 at-spi2-core cairo pango gdk-pixbuf \
         mesa-gles mesa-gbm mesa-dri-gallium mesa-vulkan-swrast \
         gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav \
@@ -267,6 +268,31 @@ ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 # image README) — the two are required together (see the producer Tier-2 smoke).
 ENV WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1
 
+# The Playwright DRIVER's allocator. Every browser shim already preloads
+# mimalloc for the browser itself; this is the node process on the other end of
+# the pipe, which still used musl malloc.
+#
+# `eval_rtt` is 500 sequential page.evaluate round trips — the driver's
+# stream/pipe and event-loop path, re-paid by every Playwright action — and it
+# is the row that did not move when the browsers got mimalloc. Preloading it
+# into node is worth +7.8% and +13.2% on that row across two ff-perf-ab runs on
+# different CPUs with the arms in opposite order (33065282215, 33065574061),
+# while the browser-only controls stay flat: click_force 1.000/0.999,
+# locator_click 1.000/1.000.
+#
+# This is an OURS-VS-OURS improvement only. It does NOT beat the official
+# image on eval_rtt: two draws against it read 0.957 and 1.022, and the n=10
+# baseline classes that row as tied. Do not quote it as a win over official.
+#
+# The secure build is used deliberately. On the driver the two are within ~2%
+# of each other (33066499518), so there is no reason to give up mimalloc's
+# hardening here — unlike the browser shims, where secure measured 10-15%
+# slower and -insecure is a paid-for choice.
+#
+# Scope: this is a container-wide ENV, so it reaches every process a user runs
+# here, not just the driver.
+ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2
+
 # The fmod interposer the webkit launcher preloads. ~10 kB; reaches
 # MiniBrowser and every auxiliary process, and nothing else — not the Node
 # driver, not chromium, not firefox.
@@ -291,6 +317,21 @@ RUN sudo touch /ms-playwright/chromium_headless_shell-${CHS_REV}/INSTALLATION_CO
       cat "$WARN" >&2; \
       echo "==========================================================" >&2; \
     fi
+
+# chromium is the only browser here with no launch shim — playwright execs the
+# binary directly — so the container-wide LD_PRELOAD above would reach it and
+# silently put mimalloc under PartitionAlloc. Every earlier decision in this
+# file deliberately left chromium's allocator alone, so give it a shim whose
+# only job is to drop the preload back to nothing.
+RUN CHS=/ms-playwright/chromium_headless_shell-${CHS_REV}/chrome-headless-shell-linux64 \
+ && sudo mv "$CHS/chrome-headless-shell" "$CHS/chrome-headless-shell.real" \
+ && printf '%s\n' \
+        '#!/bin/sh' \
+        'DIR="$(dirname "$0")"' \
+        'unset LD_PRELOAD' \
+        'exec "$DIR/chrome-headless-shell.real" "$@"' \
+  | sudo tee "$CHS/chrome-headless-shell" >/dev/null \
+ && sudo chmod +x "$CHS/chrome-headless-shell"
 
 # Firefox first: webkit's ICU libs are relative symlinks into the firefox tree,
 # so its target must already be in place when the webkit layer lands.


### PR DESCRIPTION
Every browser shim in this image already preloads mimalloc for the browser. The
node process on the other end of the pipe still used musl malloc — and
`eval_rtt` is 500 sequential `page.evaluate` round trips through exactly that
driver, re-paid by every Playwright action. It is the row that did not move when
the browsers got mimalloc.

Two `ff-perf-ab` runs, different CPUs, arms in opposite order so an ordering
bias would show:

| run | CPU | order | musl node | mimalloc node | gain |
|---|---|---|---|---|---|
| 33065282215 | Xeon 8370C | musl first | 343.2 | 318.3 | **+7.8%** |
| 33065574061 | Xeon 8573C | mimalloc first | 313.5 | 277.0 | **+13.2%** |

Browser-only controls flat in both — `click_force` 1.000/0.999,
`locator_click` 1.000/1.000 — which is what makes it readable at n=1.

**This is an ours-vs-ours improvement and I am not claiming more.** It does not
demonstrably beat the official image on that row: two draws against official
read 0.957 and **1.022**, and the n=10 baseline classes `eval_rtt` as tied
(23/100 cross-pairs). I reported the 0.957 as a win earlier today and retracted
it; this PR is the narrower claim that survived.

**Secure mimalloc, deliberately.** On the driver the secure and `-insecure`
builds are within ~2% (33066499518), so there is no reason to give up the
hardening here — unlike the browser shims, where secure measured 10-15% slower
and `-insecure` is a paid-for choice. Verified on the image that
`/usr/lib/libmimalloc.so.2` is a symlink to `libmimalloc-secure.so.2`, and added
the `mimalloc2` package, since only `mimalloc2-insecure` was installed.

### chromium needed shielding, and that is the part worth your attention

chromium is the only browser here with **no launch shim** — Playwright execs the
binary directly. A container-wide `ENV LD_PRELOAD` would therefore have reached
it and put mimalloc under PartitionAlloc, which every earlier decision in this
file deliberately avoided ("so chromium's PartitionAlloc and webkit's bmalloc
are left alone"). It now gets a shim whose only job is to `unset LD_PRELOAD`.

I did not want to quietly reverse a documented decision, and I did not want to
drop the win either, so this preserves both. If you would rather chromium simply
inherit mimalloc, deleting that shim is the one-line version — but that is a
measurement the chromium owner should make, not me.

### Your call: the ENV is container-wide

`ENV LD_PRELOAD` reaches **every process a user runs in this container** — their
test runner, their app under test, `pnpm`, everything — not just the Playwright
driver. There is no mechanism that reaches the user's node without reaching the
rest of their processes, which is precisely the scoping the existing shim
comment chose against.

That is a product decision about what this image imposes on consumers, so it is
yours. The PR can sit here green while you decide.

### Out of scope

Whether the same lever helps chromium's and webkit's drivers. It is the same
node process, so it very likely does, but those are not my arm to measure.
