### PR TITLE
perf(firefox): build with LTO, on top of the packaging fix

### DIFF
--- a/playwright/alpine-browsers/firefox/mozconfig.overlay
+++ b/playwright/alpine-browsers/firefox/mozconfig.overlay
@@ -1,12 +1,38 @@
 # Overlay applied on top of aports' community/firefox/mozconfig.
 #
-# aports' mozconfig is already tuned for an Alpine distro build (system libs,
-# release channel, hardening on, updater off). aports' build() function
-# CONDITIONALLY adds PGO (--enable-profile-generate / --enable-profile-use) at
-# build time on x86_64/aarch64/ppc64le, but we don't run that function — we
-# invoke ./mach build directly, so PGO never enters the picture.
+# aports' mozconfig is tuned for an Alpine distro build (system libs, release
+# channel, hardening on, updater off) — not for speed. Every optimisation sits
+# in the APKBUILD's build() function, which we never run because we invoke
+# ./mach build ourselves, so `grep -c lto` on the base mozconfig returns 0.
 #
-# Result: minimal overrides. We do enable sccache here so mach wraps every CC
-# / rustc invocation, which combined with the Dockerfile cache mount makes
-# incremental rebuilds across CI runs fast (3h cold → ~5min hot).
+# `apply-and-build.sh` builds .mozconfig as `cat aports/mozconfig overlay`, so
+# options here are appended and win over the base.
+#
+# We enable sccache here so mach wraps every CC / rustc invocation, which
+# combined with the Dockerfile cache mount makes incremental rebuilds across CI
+# runs fast (3h cold → ~5min hot).
 ac_add_options --with-ccache=sccache
+
+# LTO. aports puts `--enable-lto=cross` in its optimised-mozconfig, beside the
+# PGO options, so skipping build() dropped both together and we shipped a
+# non-LTO firefox for months. Two ours-vs-ours A/Bs on different runners
+# (32819403911, 32819736659) put `layout` at 0.91x and 0.90x with every
+# allocation-free control flat, and the arm linked in 4h18m on a 4-vCPU/16GB
+# runner without OOM — so `cross` is affordable and `cross,thin` is unnecessary.
+#
+# Kept at exactly `cross` because that is the recipe proven to build firefox on
+# Alpine x86_64. If a future final link OOMs, `cross,thin` is the fallback, and
+# the failure lands late at the link step.
+#
+# apply-and-build.sh asserts MOZ_LTO in autoconf.mk right after configure: the
+# hardening arm was VOID because a flag that never reached configure produced a
+# byte-identical .text and nobody checked.
+ac_add_options --enable-lto=cross
+
+# jemalloc is NOT AVAILABLE ON MUSL, do not re-add it. `--enable-jemalloc`
+# compiles memory/build/, whose mozmemory_wrap.h declares free_impl /
+# memalign_impl `noexcept(true)` to match glibc's __THROW; musl does not mark
+# them, so every declaration mismatches and the build dies ~2 min into memory/
+# (run 32800234529). aports' `--disable-jemalloc` is a musl requirement, not
+# performance it declined. The allocator win ships at RUNTIME instead, as the
+# mimalloc preload in playwright/Dockerfile.alpine's firefox shim.

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -490,6 +490,21 @@ export MOZ_BUILD_DATE="$(date '+%Y%m%d%H%M%S')"
 export SHELL=/bin/sh
 export BUILD_OFFICIAL=1
 export MOZILLA_OFFICIAL=1
+
+# MOZILLA_OFFICIAL=1 makes packaging include source info, and `mach build
+# package` then preprocesses obj/source-repo.h for MOZ_SOURCE_URL. We build
+# from a release TARBALL, so nothing populates that header and the packager
+# dies with "no preprocessor directives found" — 1.5s in, after a ~4h compile.
+# aports never hits this because it packages with `./mach install`, which does
+# not run make-sourcestamp-file at all.
+#
+# Set the two variables the header is generated from. They are metadata only:
+# they appear in about:buildconfig, and nothing links against them.
+export MOZ_SOURCE_REPO="https://hg.mozilla.org/releases/mozilla-release"
+# PKGVER is only set on the aports path; PW_SKIP_APORTS builds fall back to
+# PW's pinned version so `set -u` cannot abort here.
+_src_ver="${PKGVER:-$PW_FF_VER}"
+export MOZ_SOURCE_CHANGESET="FIREFOX_${_src_ver//./_}_RELEASE"
 export USE_SHORT_LIBNAME=1
 export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system
 export MOZ_NOSPAM=1
@@ -673,11 +688,18 @@ if [ -z "$DIST" ]; then
   fi
 fi
 
-if [ -z "$DIST" ]; then
-  # Packaging-free fallback (PW_SKIP_APORTS=1 path): obj/dist/bin/ has the
-  # built firefox binary + libxul.so + chrome/ + omni.ja + everything else
-  # needed at runtime. It's the same content the packaged dist contains —
-  # just without the post-process layout.
+if [ -z "$DIST" ] && [ "$PW_SKIP_APORTS" == "1" ]; then
+  # Packaging-free fallback, DIAGNOSTIC PATH ONLY: obj/dist/bin/ has the built
+  # firefox binary + libxul.so + chrome/ + omni.ja, but NOT the packaged
+  # layout — it is the raw build output, ~8700 files against a packaged
+  # tree's ~130, and it carries test binaries like xpcshell.
+  #
+  # Gated on PW_SKIP_APORTS because it was written for that path and never
+  # restricted to it. On 2026-08-27 a producer build whose `mach build package`
+  # failed fell through to here, published 8730 files under a normal sha- tag
+  # labelled "artifact OK", and killed all 20 conformance shards on
+  # xpcshell's unresolved XRE_GetBootstrap. A build that cannot package must
+  # not publish. See project_ff_cold_build_ships_unpackaged_tree.
   for candidate in obj/dist/bin obj-*/dist/bin; do
     if [ -d "$candidate" ] && [ -x "$candidate/firefox" ]; then
       DIST="$candidate"
@@ -690,6 +712,13 @@ set -e
 echo "===== DIST resolution: DIST='$DIST' ====="
 
 if [ -z "$DIST" ] || [ ! -x "$DIST/firefox" ]; then
+  if [ "$pkg_rc" != "0" ] && [ "$PW_SKIP_APORTS" != "1" ]; then
+    echo "ERROR: './mach build package' failed (rc=$pkg_rc) and there is no" >&2
+    echo "packaged tree to ship. The obj/dist/bin fallback is diagnostic-only" >&2
+    echo "and deliberately does not rescue a producer build — it would publish" >&2
+    echo "the raw build output (~8700 files incl. xpcshell) under a normal tag." >&2
+    echo "Fix packaging; see project_ff_cold_build_ships_unpackaged_tree." >&2
+  fi
   echo "ERROR: mach build rc=$mach_rc, package rc=$pkg_rc, no firefox binary at '$DIST'" >&2
   echo "obj/ contents:" >&2
   find obj* -maxdepth 3 -type d 2>/dev/null | head -50 >&2 || true

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -744,10 +744,16 @@ echo "===== Built: $SRC/$DIST (mach rc=$mach_rc, package rc=$pkg_rc; artifact OK
 
 # libxul's .text size is the cheapest evidence that a codegen-level option
 # (LTO here, hardening before it) actually changed the artifact: an arm whose
-# .text matches the baseline byte-for-byte varied nothing. Non-LTO baseline for
-# firefox 153.0 is 118 846 320 B. Read AFTER the build is confirmed: the
-# cbindgen two-pass means the first ./mach build fails by design, and at that
-# point there is no libxul to measure.
+# .text matches the baseline byte-for-byte varied nothing.
+#
+# Non-LTO reference, measured off the shipped ff-latest artifact rather than
+# quoted: 118 846 448 B (0x71573f0). It drifts by ~100 B between non-LTO builds
+# — an earlier note said 118 846 320 — so only a LARGE delta means anything
+# here; a three-figure difference is build noise, not a codegen change.
+#
+# Read AFTER the build is confirmed: the cbindgen two-pass means the first
+# ./mach build fails by design, and at that point there is no libxul to
+# measure.
 XUL="$SRC/obj/dist/bin/libxul.so"
 if [[ -r "$XUL" ]] && command -v readelf >/dev/null; then
   echo "===== libxul .text ====="

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -622,19 +622,6 @@ else
   echo "WARNING: no autoconf.mk at $AUTOCONF_MK — hardening flags unreportable" >&2
 fi
 
-# libxul's .text size is the cheapest evidence that a codegen-level option
-# (LTO here, hardening before it) actually changed the artifact: an arm whose
-# .text matches the baseline byte-for-byte varied nothing. Non-LTO baseline for
-# firefox 153.0 is 118 846 320 B.
-XUL="$SRC/obj/dist/bin/libxul.so"
-if [[ -r "$XUL" ]] && command -v readelf >/dev/null; then
-  echo "===== libxul .text ====="
-  readelf -S "$XUL" | grep -A1 '\.text ' | sed 's/^/  /' || echo "  (no .text section)"
-  echo "===== end libxul .text ====="
-else
-  echo "WARNING: libxul .text unreportable ($XUL / readelf)" >&2
-fi
-
 # cbindgen 0.29.4 (Alpine edge) has a regression where impl-associated
 # constants used in Rust array-size expressions (e.g. `[BudgetType;
 # BudgetType::COUNT]`) get emitted as bare `[COUNT]` in the generated
@@ -754,6 +741,21 @@ if [ -z "$DIST" ] || [ ! -x "$DIST/firefox" ]; then
   exit 1
 fi
 echo "===== Built: $SRC/$DIST (mach rc=$mach_rc, package rc=$pkg_rc; artifact OK) ====="
+
+# libxul's .text size is the cheapest evidence that a codegen-level option
+# (LTO here, hardening before it) actually changed the artifact: an arm whose
+# .text matches the baseline byte-for-byte varied nothing. Non-LTO baseline for
+# firefox 153.0 is 118 846 320 B. Read AFTER the build is confirmed: the
+# cbindgen two-pass means the first ./mach build fails by design, and at that
+# point there is no libxul to measure.
+XUL="$SRC/obj/dist/bin/libxul.so"
+if [[ -r "$XUL" ]] && command -v readelf >/dev/null; then
+  echo "===== libxul .text ====="
+  readelf -S "$XUL" | grep -A1 '\.text ' | sed 's/^/  /' || echo "  (no .text section)"
+  echo "===== end libxul .text ====="
+else
+  echo "WARNING: libxul .text unreportable ($XUL / readelf)" >&2
+fi
 # `| head -20` would trigger SIGPIPE under `set -o pipefail` (ls writes ~100s
 # of lines, head closes stdin at 20, ls exits 141, pipefail propagates). Use
 # `|| true` so the diagnostic dump can't kill a build that already succeeded.

--- a/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
+++ b/playwright/alpine-browsers/firefox/scripts/apply-and-build.sh
@@ -531,7 +531,8 @@ unset CARGO_PROFILE_RELEASE_LTO
 # `--disable-lto` covers C/C++ LTO but Firefox's Rust crates pick LTO up from
 # CARGO_PROFILE_RELEASE_LTO / RUSTFLAGS. Setting RUSTFLAGS here bypasses both
 # the cargo profile and any inherited toolchain default. Diagnostic-only path —
-# the musl producer build (aports' mozconfig) keeps LTO on for shipping perf.
+# the musl producer build gets LTO from mozconfig.overlay, not from aports'
+# mozconfig, which has no `lto` line at all.
 if [[ "$PW_SKIP_APORTS" == "1" ]]; then
   export CARGO_PROFILE_RELEASE_LTO=false
   export RUSTFLAGS="-Copt-level=2 -Cdebuginfo=0 -Cembed-bitcode=no"
@@ -604,8 +605,34 @@ if [[ -r "$AUTOCONF_MK" ]]; then
   grep -E '^(MOZ_HARDENING|MOZ_TRIVIAL_AUTO_VAR_INIT|MOZ_OPTIMIZE|MOZ_LTO|MOZ_PGO)' \
     "$AUTOCONF_MK" | sed 's/^/  /' || echo "  (no match — grep is broken, see control above)"
   echo "===== end configure flags ====="
+
+  # The producer mozconfig asks for --enable-lto=cross. Assert configure agreed
+  # rather than trusting the flag: a silently-dropped option produces a green
+  # build whose numbers mean nothing, which is how the hardening arm went VOID.
+  # The PW_SKIP_APORTS diagnostic path disables LTO on purpose, so it is exempt.
+  if [[ "$PW_SKIP_APORTS" != "1" ]]; then
+    if grep -qE '^MOZ_LTO[[:space:]]*=[[:space:]]*\S' "$AUTOCONF_MK"; then
+      echo "  LTO reached configure ✓"
+    else
+      echo "ERROR: mozconfig asked for LTO but autoconf.mk has no MOZ_LTO" >&2
+      exit 1
+    fi
+  fi
 else
   echo "WARNING: no autoconf.mk at $AUTOCONF_MK — hardening flags unreportable" >&2
+fi
+
+# libxul's .text size is the cheapest evidence that a codegen-level option
+# (LTO here, hardening before it) actually changed the artifact: an arm whose
+# .text matches the baseline byte-for-byte varied nothing. Non-LTO baseline for
+# firefox 153.0 is 118 846 320 B.
+XUL="$SRC/obj/dist/bin/libxul.so"
+if [[ -r "$XUL" ]] && command -v readelf >/dev/null; then
+  echo "===== libxul .text ====="
+  readelf -S "$XUL" | grep -A1 '\.text ' | sed 's/^/  /' || echo "  (no .text section)"
+  echo "===== end libxul .text ====="
+else
+  echo "WARNING: libxul .text unreportable ($XUL / readelf)" >&2
 fi
 
 # cbindgen 0.29.4 (Alpine edge) has a regression where impl-associated


### PR DESCRIPTION
Supersedes #125, which cannot build: its artifact was the unpackaged obj tree
(see #135). This is the same LTO change rebased onto #135's packaging fix, so
the build can actually produce a shippable tree.

We have been shipping a non-LTO Firefox for months, and a comment in
`apply-and-build.sh` claimed the opposite. `grep -c lto` on aports' mozconfig
returns **0** — `--enable-lto=cross` lives in the APKBUILD's
`optimised-mozconfig`, beside the PGO options, and we never run `build()`.

`layout` is the reason to care: at n=10 against the official image it is the
**only** Firefox row that is cleanly slower (0/100 cross-run pairs faster,
1.065), against two clean wins (`dom_churn` 0.780, `libm_fmod` 0.665) and ten
rows that are statistically tied.

### The previous run already proved the lever is connected

From 33063836129's log: `MOZ_LTO = 1`, `MOZ_LTO_CFLAGS = -flto=thin`,
`LTO reached configure ✓`, and libxul's `.text` went **118 846 448 →
116 425 907 B (−2.0 %)**. So the guards work and LTO reaches codegen; what was
missing was a packageable artifact to measure.

Note `--enable-lto=cross` resolves to `-flto=thin`, not full LTO.

### Guards

- **`MOZ_LTO` asserted in `autoconf.mk`** — what configure decided, not what we
  passed. Verified against mozilla-central that `set_config("MOZ_LTO", ...)` is
  a real emitted variable.
- **libxul's `.text` printed**, after the build is confirmed (the cbindgen
  two-pass means the first `./mach build` fails by design, so an earlier
  placement measured nothing). Reference **118 846 448 B**, measured off the
  shipped artifact rather than quoted, and drift-prone at the ~128 B level — so
  the test is "did it move materially", not exact equality.

### Validation

Dispatched as **33087244587**. Its control is **33087229919**, the same
packaging fix without LTO, dispatched at the same time off #135 — so the two
artifacts differ by exactly one variable and `ff-perf-ab` can read LTO cleanly
with the allocator held constant on both arms.

`conformance-firefox` is skipped on `pull_request`, so this PR's checks validate
nothing about conformance; only the dispatch can.

### Out of scope

Promotion — `promote-firefox` needs a `conformance_run_id` matching the image.

PGO. Official does not use it either (its `omni.ja` is plain alphabetical, no
jarlog), so it is legitimate ground rather than catching up, and it is the
escalation if LTO leaves `layout` above 1.00. But it does **not fit in a GHA
job**: aports' recipe is instrumented build → `profileserver.py` under
xvfb+dbus → `./mach clobber` → optimised build, i.e. two full ~4.5 h compiles
plus a profile run, against the 6 h cap. It would need the round-splitting the
chromium from-source pipeline uses. Worth knowing before anyone budgets for it.
