### PR TITLE
perf(webkit): build WPE with ThinLTO — EXPERIMENT, not for merge as-is

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -8,11 +8,24 @@ ARG FF_REV=1538
 ARG WK_REV=2336
 ARG BASE_IMAGE=jclaveau/alpine-dood-pnpm:latest
 
+# Which WebKit artifact to consume, held SEPARATE from WK_REV on purpose.
+# WK_REV is browsers.json's revision and decides where PW discovers the
+# browser (/ms-playwright/webkit-${WK_REV}/), so it cannot be repointed at an
+# experiment without breaking discovery. This tag decides only which producer
+# artifact the bits come from. Normally `wk-${WK_REV}`, the promoted one.
+#
+# EXPERIMENT (perf/webkit-thinlto): pinned to this branch's own ThinLTO
+# artifact so the arm can be measured. Verified connected before measuring —
+# against wk-2336 the .text grew 91.9 -> 106.1 MB (+15.4%) and .eh_frame
+# shrank 20.7%, which is the same shape chromium's ThinLTO arm showed. Revert
+# this default to wk-${WK_REV} before any merge.
+ARG WK_SOURCE_TAG=wk-sha-7210a5d296bb2ff7fc016c1b53e67100da31097d
+
 # Producer-image stage aliases — Renovate's custom manager bumps the tag
 # revision in lockstep with PLAYWRIGHT_VERSION below.
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:chs-${CHS_REV} AS chs-source
 FROM ghcr.io/jclaveau/playwright-alpine-browsers:ff-${FF_REV} AS ff-source
-FROM ghcr.io/jclaveau/playwright-alpine-browsers:wk-${WK_REV} AS wk-source
+FROM ghcr.io/jclaveau/playwright-alpine-browsers:${WK_SOURCE_TAG} AS wk-source
 
 # libfastfmod.so — a drop-in `fmod` for musl, preloaded under WebKit alongside
 # mimalloc. musl's fmod walks the exponent difference one bit per iteration

--- a/playwright/alpine-browsers/webkit/cmake-flags.overlay
+++ b/playwright/alpine-browsers/webkit/cmake-flags.overlay
@@ -37,12 +37,22 @@ CMAKE_SHARED_FLAGS=(
   # Sampling profiler relies on glibc-ish signal/timer plumbing; aports turns it off.
   -DENABLE_SAMPLING_PROFILER=OFF
 
-  # LTO (thin) — shrinks the shipped libs meaningfully, but the link step's
-  # memory + wall-time balloon, risking the GHA build cap on this already
-  # multi-hour build (same reason chromium skips is_official_build's PGO/LTO).
-  # Kept wired-but-OFF: uncomment when building on a higher-cap / self-hosted
-  # runner. Values: thin | full.
-  # -DLTO_MODE=thin
+  # LTO (thin). Alpine's own community/webkit2gtk-6.0 APKBUILD sets this for
+  # x86_64 alongside the clang + lld + llvm-ar we already match, and this
+  # repo's chromium arms measured ThinLTO ALONE at geomean 1.42 -> 1.31, so
+  # the "skip it like chromium does" rationale this line used to carry is
+  # stale — chromium built those arms and they won. Values: thin | full.
+  #
+  # The original worry was the link step's memory and wall-time on an already
+  # multi-hour build. That is what this arm is measuring; if the link blows the
+  # runner, the round fails visibly rather than silently, and the flag goes
+  # back to being commented out.
+  #
+  # MUST be built COLD. apply-and-build-port.sh runs cmake configure only
+  # `if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]`, so a dispatch that resumes an
+  # existing checkpoint image skips configure entirely, never puts this in the
+  # cache, and hands back an arm that changed nothing while looking green.
+  -DLTO_MODE=thin
 
   # Docs need gi-docgen which isn't a CI dep; we don't ship them anyway.
   -DENABLE_DOCUMENTATION=OFF


### PR DESCRIPTION
**Experiment arm, not a merge request.** It exists to produce a number. Two things must be undone before any of it could merge: the `-DLTO_MODE=thin` decision itself, and the `WK_SOURCE_TAG` default, which is pinned to this branch's artifact so the arm gets a consumer image at all.

Alpine's own `community/webkit2gtk-6.0` APKBUILD sets `-DLTO_MODE=thin` for x86_64 alongside the clang + lld + llvm-ar we already match, and this repo's chromium arms measured ThinLTO **alone** at geomean 1.42 → 1.31. The comment justifying our OFF said "same reason chromium skips `is_official_build`'s PGO/LTO" — stale; chromium built those arms and they won.

## Verified connected before measuring

The cold chain was the whole risk: `apply-and-build-port.sh` runs cmake configure only `if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]`, so a resumed dispatch would have ignored the flag and handed back a flat arm that looked perfectly green. A fresh branch sha gives sha-scoped round images, hence a cold chain. Confirmed on the artifact rather than assumed:

| | `wk-2336` | this arm |
|---|---|---|
| `.text` | 91,881,817 | **106,058,761 (+15.4%)** |
| `.eh_frame` | 11,264,616 | **8,932,336 (−20.7%)** |
| `.data.rel.ro` | 3,390,912 | 3,369,632 |
| relocations | 320,694 | 318,186 |
| file size | 126.2 MB | 137.5 MB |

`.text` growing is the same signature chromium's ThinLTO arm showed — which is also exactly why `.text` size is a **connectivity check and not a pass/fail**.

## The plumbing commit is the reusable part

The arm built and then could not be measured, because `Dockerfile.alpine` used `WK_REV` for two different jobs: which artifact to `COPY --from`, and where PW discovers the browser. The second is browsers.json's revision and cannot move — repoint `WK_REV` and PW simply stops finding webkit. `WK_SOURCE_TAG` splits them, defaulting to `wk-${WK_REV}`.

Every producer-side webkit arm will need this; mimalloc and fmod were both consumer-side, which is why it had not come up. **If you want only one thing off this branch, take that commit** — it is useful whether or not ThinLTO wins.

## What I have not claimed

No perf number yet. The consumer image is building and the probe follows, paired by CPU per the `libm_fmod` fingerprint rule. The original objection to this flag was link-step memory and wall time on an already multi-hour build — the chain went green, so the link fits, but that is a statement about the build, not about the browser.

Open question if it wins: promotion. `promote-webkit` now requires `refs/heads/main`, so this branch cannot ship `wk-latest` by accident, but merging a ThinLTO default would need a fresh cold chain on main and I would want that sequenced deliberately rather than as a side effect of a merge.
