### PR TITLE
perf(webkit): a no-preload control — EXPERIMENT

### DIFF
--- a/playwright/Dockerfile.alpine
+++ b/playwright/Dockerfile.alpine
@@ -189,7 +189,12 @@ RUN sudo mv /ms-playwright/webkit-${WK_REV}/pw_run.sh \
  && printf '%s\n' \
         '#!/bin/sh' \
         'DIR="$(dirname "$0")"' \
-        'export LD_PRELOAD=/usr/lib/libmimalloc-insecure.so.2:/usr/lib/libfastfmod.so' \
+        # EXPERIMENT (perf/webkit-no-preload): both preloads OFF, to
+        # re-take the mimalloc verdict on #129's rescaled kernels. The
+        # goto_warm regression was measured when that metric was ~24 ms
+        # absolute; it is ~268 ms now, so the old reading cannot simply
+        # be carried forward — in either direction.
+        'true # LD_PRELOAD deliberately unset' \
         'exec "$DIR/pw_run.real.sh" "$@"' \
   | sudo tee /ms-playwright/webkit-${WK_REV}/pw_run.sh >/dev/null \
  && sudo chmod +x /ms-playwright/webkit-${WK_REV}/pw_run.sh


### PR DESCRIPTION
**Experiment arm, not a merge request.** It exists to build an image so `perf-probe` can measure it; I will report the number and close it.

#129 rescaled the probe's fixture, and `goto_warm` went from a ~24 ms metric to a ~268 ms one. That matters more than it sounds: **every conclusion I drew about the allocator's effect on `goto_warm` was drawn at 24 ms**, where the metric's own null arm sat at 1.11–1.12 while every other null read 1.00 — i.e. the effect I was reporting was below the instrument's resolution.

Those readings cannot be carried forward now that it *can* resolve, and I want to be explicit that this cuts both ways: the regression may be real and was under-measured, or it may evaporate entirely. I do not know which, and neither does the +0.03/+0.06/+0.20 spread I reported at the time — that spread is itself what an unresolvable effect looks like.

This arm turns **both** webkit preloads off so the comparison can be re-taken on the current kernels. It is the control that #133 does not provide: that arm varies mimalloc's *behaviour*, this one varies its *presence*.

It also gives something we have never actually had — a current, rescaled-kernel picture of webkit with no preloads at all, against which both shipped changes can be re-scored rather than trusted from pre-#129 numbers.

**Not for merge.** Both preloads are shipped and both are justified by measurements that *did* resolve:

| | before | after |
|---|---|---|
| `context_page` | 1.24–1.31 | **0.94–0.96** |
| `goto_cold` | 1.46–1.58 | **1.09–1.15** |
| `libm_fmod` | ~10 | **~3.1** |

If this control shows `goto_warm` improving without the preloads by an amount the metric can now resolve, that is a real tradeoff to weigh against those three rows — not an automatic revert.
