### PR TITLE
perf(webkit): pack relative relocations as DT_RELR — EXPERIMENT

### DIFF
--- a/playwright/alpine-browsers/webkit/cmake-flags.overlay
+++ b/playwright/alpine-browsers/webkit/cmake-flags.overlay
@@ -11,6 +11,33 @@
 # Bash array form so apply-and-build.sh can splice this into a single
 # cmake invocation per port.
 
+# EXPERIMENT (perf/webkit-relr): pack relative relocations as DT_RELR.
+#
+# `launch` is WebKit's largest remaining gap (1.36x official) and it is the
+# LOADER, not our build's shape. Measured on a quiet runner (EPYC 9V74), a bare
+# dlopen of libWPEWebKit takes 48.7 ms for ours against 28.5 ms for official's
+# — while ours has FEWER relocations (320,694 vs 339,342), a SMALLER .text and
+# fewer DT_NEEDED. That is ~1.8x per relocation, i.e. musl's ld.so applying
+# them, and the two build-shape candidates (the DSO closure, BIND_NOW) are
+# already dead by measurement.
+#
+# 313,989 of our 320,694 relocations are R_X86_64_RELATIVE, and those are
+# exactly what DT_RELR compresses: a bitmap instead of 24 bytes each, which
+# both shrinks the file and cuts the loader's work per relocation.
+#
+# Feasibility gated BEFORE spending a build (alpine:edge, musl 1.2.6-r2): the
+# linker accepts `-z pack-relative-relocs`, emits DT_RELR/RELRSZ/RELRENT,
+# leaves zero R_X86_64_RELATIVE behind, and musl's loader applies them
+# correctly — a dlopen'd test library returned a live pointer into its own
+# relocated table.
+#
+# Set here rather than relying on the script's `: "${LDFLAGS:=-fuse-ld=lld}"`
+# default, which only applies when LDFLAGS is unset; the overlay is sourced
+# first, so this wins. Keep -fuse-ld=lld — dropping it would silently change
+# the linker as well and confound the arm.
+LDFLAGS="-fuse-ld=lld -Wl,-z,pack-relative-relocs"
+export LDFLAGS
+
 CMAKE_SHARED_FLAGS=(
   -DCMAKE_BUILD_TYPE=Release
   -DCMAKE_C_COMPILER_LAUNCHER=sccache


### PR DESCRIPTION
**Experiment arm, not a merge request.** The number decides it; a green build only says the link worked.

`launch` is WebKit's largest remaining gap — **1.36x** official on the current shipped image — and it is the **loader**, not our build's shape. On a quiet runner (EPYC 9V74, via the probe merged in #134):

| | ours | official |
|---|---|---|
| `dlopen` best-of-12, LAZY | **48.7 ms** | **28.5 ms** |
| `dlopen` best-of-12, NOW | 49.1 ms | 30.8 ms |
| relocations | 320,694 | 339,342 |
| `.text` | 91.9 MB | 98.6 MB |
| `DT_NEEDED` | 60 | 70 |

Ours is the **leaner artifact on every static axis and still loads 1.7x slower** — roughly 1.8x per relocation. Both build-shape candidates are already dead by measurement rather than argument: the DSO closure (we are the leaner side, so chromium's explanation does not transfer) and `BIND_NOW` (official's own `RTLD_NOW` vs `RTLD_LAZY` costs it 2.3 ms, not 20).

313,989 of our 320,694 relocations are `R_X86_64_RELATIVE`, which is exactly what `DT_RELR` compresses — a bitmap instead of 24 bytes each, so both the file and the loader's per-relocation work shrink.

## Gated for feasibility before spending the build

This is a ~4h cold chain, and it rests on musl supporting a relocation format it might simply not. Checked first, on `alpine:edge` with musl 1.2.6-r2:

- the linker accepts `-Wl,-z,pack-relative-relocs`
- it emits `DT_RELR` / `RELRSZ` / `RELRENT`
- zero `R_X86_64_RELATIVE` remain
- **musl's loader applies them** — a `dlopen`'d test library returned a live pointer into its own relocated table

Five minutes against four hours, and it is the difference between an arm and a rebuild on a hunch.

## Notes for review

`LDFLAGS` is set in the overlay rather than left to `apply-and-build-port.sh`'s `: "${LDFLAGS:=-fuse-ld=lld}"`, which only applies when unset — the overlay is sourced first, so this wins. `-fuse-ld=lld` is kept deliberately: dropping it would change the linker as well and confound the arm.

It must be **cold**, which a fresh branch sha gives (round images are sha-scoped): `apply-and-build-port.sh` runs cmake configure only `if [[ ! -f "$BUILD_DIR/CMakeCache.txt" ]]`, so a resumed dispatch would ignore this and return a flat arm that looks green.

I will verify `DT_RELR` is present on the built artifact before reading any perf number, the same way I verified ThinLTO reached its build in #141 — a linker flag in a script is what you *set*, not what the toolchain did.

Measuring it will need #141's `WK_SOURCE_TAG` commit (or an equivalent), since the consumer pins `WK_REV` for both the artifact tag and PW's discovery path.
