### PR TITLE
fix(firefox): fetch aports from a second host, and widen the budget

### DIFF
--- a/playwright/alpine-browsers/firefox/scripts/fetch-aports.sh
+++ b/playwright/alpine-browsers/firefox/scripts/fetch-aports.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# Fetch community/firefox from gitlab.alpinelinux.org/alpine/aports.
+# Fetch community/firefox from alpine's aports, pinned to ALPINE_APORTS_REF.
 #
 # Usage: fetch-aports.sh <out_dir>
 # Reads: ALPINE_APORTS_REF (from versions.env)
 # Writes: <out_dir>/{APKBUILD, *.patch, mozconfig, ...}
 #
-# We curl individual files via the GitLab API rather than `git clone` the whole
-# aports repo (~hundreds of MB, mostly irrelevant). The community/firefox tree
-# is small (~20 files).
+# We curl individual files rather than `git clone` the whole aports repo
+# (~hundreds of MB, mostly irrelevant). The community/firefox tree is ~23 files.
 
 set -euo pipefail
 
@@ -16,37 +15,84 @@ REF="${ALPINE_APORTS_REF:?ALPINE_APORTS_REF must be set}"
 
 mkdir -p "$OUT"
 
-API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
-LIST_URL="$API/repository/tree?path=community/firefox&ref=$REF&per_page=100"
+# gitlab.alpinelinux.org is intermittently unreachable from GHA runners, and it
+# fails at minute one of a 4-hour build. On 2026-08-27 it killed three separate
+# firefox builds with `curl: (28) Connection timed out after 20002 ms`, twice on
+# the same branch; the old budget was 3 tries and ~75 s total, which is nothing
+# against an outage lasting minutes.
+#
+# Worse, it does not READ as a network fault: this script owns its retry loop,
+# so exhausting it returns non-zero and BuildKit blames the `RUN` line of the
+# Dockerfile — i.e. whichever build script the branch happened to change. Every
+# message here names the network explicitly for that reason.
+#
+# Two levers, both cheap next to a 4 h compile:
+#   - a wider budget: 5 rounds, 30 s connect timeout, backoff 5/10/20/30 s
+#   - a SECOND HOST. github.com/alpinelinux/aports is a true mirror, verified at
+#     the pinned sha 66e79518: same 23-file listing and a byte-identical
+#     APKBUILD (md5 28baf980f0c6602e8a8683548774ca86) as gitlab serves. A
+#     fallback beats more retries against one dead host.
+ATTEMPTS=5
+CONNECT_TIMEOUT=30
+MAX_TIME=180
 
-# gitlab.alpinelinux.org drops connections: run 32892351327 lost a whole Firefox
-# round to `curl: (28) Failed to connect ... after 133306 ms`, and the aports
-# fetch was the only un-retried curl left in the build. Same 3-try shape as
-# firefox/scripts/fetch-pw-patches.sh — duplicated rather than shared because
-# each image COPYs only its own scripts/ dir. --connect-timeout so a dead socket
-# fails fast enough for the retries to fit inside the step.
-retry_curl() {
-  local n=1
-  while (( n <= 3 )); do
-    if curl -fsSL --connect-timeout 20 "$@"; then
-      return 0
+GL_API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
+GL_LIST="$GL_API/repository/tree?path=community/firefox&ref=$REF&per_page=100"
+GL_RAW="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/firefox"
+
+GH_LIST="https://api.github.com/repos/alpinelinux/aports/contents/community/firefox?ref=$REF"
+GH_RAW="https://raw.githubusercontent.com/alpinelinux/aports/$REF/community/firefox"
+
+# Try both hosts, then back off and try both again. `what` is only for the
+# message, so a failure says which artifact AND which host, not just a URL.
+fetch_both_hosts() {
+  local what="$1" primary="$2" fallback="$3"
+  shift 3
+  local n=1 url host backoff
+  while (( n <= ATTEMPTS )); do
+    for host in gitlab github; do
+      if [[ "$host" == gitlab ]]; then
+        url="$primary"
+      else
+        url="$fallback"
+      fi
+      if curl -fsSL --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+              "$url" "$@"; then
+        if (( n > 1 )); then
+          echo "  recovered: $what from $host on round $n" >&2
+        fi
+        return 0
+      fi
+      echo "  NETWORK: $what unreachable at $host (round $n/$ATTEMPTS)" >&2
+    done
+    if (( n < ATTEMPTS )); then
+      backoff=$(( n * 5 < 30 ? n * 5 : 30 ))
+      echo "  NETWORK: both hosts failed, sleeping ${backoff}s" >&2
+      sleep "$backoff"
     fi
-    echo "  retry $n/3 (gitlab unreachable?) — sleep $((n*5))s" >&2
-    sleep $((n*5))
     n=$((n+1))
   done
+  echo "fetch-aports: NETWORK FAILURE — $what unreachable at BOTH" >&2
+  echo "  gitlab.alpinelinux.org and github.com after $ATTEMPTS rounds." >&2
+  echo "  This is an upstream/network fault, NOT the build scripts. BuildKit" >&2
+  echo "  will attribute it to the Dockerfile RUN line; ignore that." >&2
   return 1
 }
 
-# List then fetch each file. jq parses the GitLab API response.
-files=$(retry_curl "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
+# GitLab calls them "blob", GitHub calls them "file" — accept either so one
+# listing parser serves both hosts.
+fetch_both_hosts "file listing" "$GL_LIST" "$GH_LIST" -o "$OUT/.listing.json"
+files=$(jq -r '.[] | select(.type=="blob" or .type=="file") | .name' "$OUT/.listing.json")
+rm -f "$OUT/.listing.json"
 
-[[ -z "$files" ]] && { echo "fetch-aports: no files at ref=$REF (gitlab API returned nothing)" >&2; exit 1; }
+if [[ -z "$files" ]]; then
+  echo "fetch-aports: no files at ref=$REF (listing empty — wrong ref?)" >&2
+  exit 1
+fi
 
 for f in $files; do
-  raw="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/firefox/$f"
   echo "  fetch $f"
-  retry_curl "$raw" -o "$OUT/$f"
+  fetch_both_hosts "$f" "$GL_RAW/$f" "$GH_RAW/$f" -o "$OUT/$f"
 done
 
 echo "aports community/firefox fetched to $OUT ($(ls -1 "$OUT" | wc -l) files)"


### PR DESCRIPTION
`gitlab.alpinelinux.org` killed **three** firefox builds today with
`curl: (28) Connection timed out after 20002 ms` — twice on the same branch, and
once on its paired control while the other arm sailed past the same step. So it
is intermittently unreachable from GHA runners rather than down, and the budget
was far too thin to ride it out: 3 tries, ~75 s total, spent at minute one of a
4-hour build.

It also does not READ as a network fault. This script owns its retry loop, so
exhausting it returns non-zero and BuildKit attributes the failure to the
Dockerfile `RUN` line — which, on a branch that changed a build script, is the
changed file. The summary points at your diff while the cause is upstream; it
nearly got charged to my packaging change. Every message here now names the
network explicitly, including a closing line telling the reader to ignore
BuildKit's attribution.

### More retries is the weaker half; a second host is the fix

`github.com/alpinelinux/aports` is a true mirror, and I verified that rather
than assuming it — at the pinned sha `66e79518`:

| | gitlab | github |
|---|---|---|
| listing | 23 files | **23 files, identical set** |
| `APKBUILD` md5 | `28baf980f0c6602e8a8683548774ca86` | **same** |

Each round now tries gitlab then github before backing off. Budget: 5 rounds,
30 s connect timeout, 180 s max, backoff 5/10/20/30 s — worst case ~6 min
against a 4 h compile, which is free.

The listing parser accepts GitLab's `"blob"` and GitHub's `"file"` so one code
path serves both hosts.

### Both paths exercised, not assumed

- normal run: fetches the correct 23 files, `APKBUILD` md5 matches known-good;
- **with gitlab pointed at an unroutable host**: logs `NETWORK: … unreachable at
  gitlab` per file, recovers from github, and produces the same 23 files with
  the same md5.

A fallback that has never been executed is not a fallback, and this one has now
run end to end with the primary fully black-holed.

### Out of scope, but you will want to route it

`chromium-headless-shell/scripts/fetch-aports.sh` has the **identical** 3-try
`retry_curl` and the identical exposure — the two are deliberately duplicated
because each image COPYs only its own `scripts/` dir. I did not touch it; it is
not my arm. The same patch applies almost verbatim (only the `community/<pkg>`
path and the ref variable differ).

### Note on cost

This file is inside `patchset-hash.sh`, so merging it forces a cold firefox
reseed on the next build. That is unavoidable for any change to the fetch path,
and cheaper than losing another 4 h build to a 20-second timeout.
