### PR TITLE
fix(chromium): fetch aports from a second host, and exercise the fallback

### DIFF
--- a/.github/workflows/tests-aports.yml
+++ b/.github/workflows/tests-aports.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'playwright/alpine-browsers/versions.env'
       - 'playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh'
+      - 'playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh'
+      - 'playwright/alpine-browsers/chromium-headless-shell/tests/fetch-aports-fallback.sh'
       - 'tests/aports/**'
       - '.github/workflows/tests-aports.yml'
   push:
@@ -19,6 +21,8 @@ on:
     paths:
       - 'playwright/alpine-browsers/versions.env'
       - 'playwright/alpine-browsers/chromium-headless-shell/scripts/resolve-aports-ref.sh'
+      - 'playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh'
+      - 'playwright/alpine-browsers/chromium-headless-shell/tests/fetch-aports-fallback.sh'
       - 'tests/aports/**'
 
 permissions:
@@ -35,3 +39,17 @@ jobs:
         run: bash tests/aports/test-aports-pkgver.sh
       - name: versions.env consistency
         run: bash tests/aports/test-versions-env-consistency.sh
+
+      # Exercises BOTH hosts of the chromium aports fetch, including the
+      # negative control where both are blackholed. A fallback that has never
+      # executed is not a fallback, and this one guards the head of a chain
+      # whose cold path is 25-30 h — the failure it defends against cost three
+      # firefox builds on 2026-08-27.
+      #
+      # It talks to the network on purpose: the claim being tested is that
+      # github.com/alpinelinux/aports still mirrors gitlab byte-for-byte at our
+      # pinned sha, and a mocked version of that would assert nothing.
+      - name: aports fetch failover (both hosts)
+        run: |
+          set -a; . playwright/alpine-browsers/versions.env; set +a
+          bash playwright/alpine-browsers/chromium-headless-shell/tests/fetch-aports-fallback.sh

--- a/playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/scripts/fetch-aports.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Fetch community/chromium from gitlab.alpinelinux.org/alpine/aports.
+# Fetch community/chromium from alpine's aports, pinned to
+# ALPINE_APORTS_CHROMIUM_REF.
 #
 # We pull aports' APKBUILD + *.patch files (musl-side patches: sandbox-musl,
 # tid-caching-musl, etc.) so we can build Chromium for musl on top of vanilla
@@ -18,36 +19,103 @@ REF="${ALPINE_APORTS_CHROMIUM_REF:?ALPINE_APORTS_CHROMIUM_REF must be set}"
 
 mkdir -p "$OUT"
 
-API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
-LIST_URL="$API/repository/tree?path=community/chromium&ref=$REF&per_page=100"
+# gitlab.alpinelinux.org is intermittently unreachable from GHA runners, and it
+# fails at minute one of a multi-hour build. On 2026-08-27 it killed three
+# separate firefox builds with `curl: (28) Connection timed out`; the old budget
+# here was 3 tries and ~75 s total, which is nothing against an outage lasting
+# minutes. Chromium's exposure is worse than firefox's, not better — this runs
+# at the head of a chain whose cold path is 25-30 h.
+#
+# Worse, it does not READ as a network fault: this script owns its retry loop,
+# so exhausting it returns non-zero and BuildKit blames the `RUN` line of the
+# Dockerfile — i.e. whichever build script the branch happened to change. Every
+# message here names the network explicitly for that reason.
+#
+# Two levers, both cheap next to a 25 h compile:
+#   - a wider budget: 5 rounds, 30 s connect timeout, backoff 5/10/20/30 s
+#   - a SECOND HOST. github.com/alpinelinux/aports is a true mirror, verified at
+#     THIS package's pinned sha 124cc885 rather than inherited from firefox's
+#     check against a different ref: the same 25-file listing from both hosts,
+#     and a byte-identical APKBUILD (md5 ea152f1882c767aed832842caf3286e0).
+#     A fallback beats more retries against one dead host.
+# Overridable so the fallback test can run all three cases in seconds rather
+# than in the six minutes the real budget takes.
+ATTEMPTS="${APORTS_ATTEMPTS:-5}"
+CONNECT_TIMEOUT="${APORTS_CONNECT_TIMEOUT:-30}"
+MAX_TIME="${APORTS_MAX_TIME:-180}"
 
-# gitlab.alpinelinux.org drops connections: run 32892351327 lost a whole Firefox
-# round to `curl: (28) Failed to connect ... after 133306 ms`, and the aports
-# fetch was the only un-retried curl left in the build. Same 3-try shape as
-# firefox/scripts/fetch-pw-patches.sh — duplicated rather than shared because
-# each image COPYs only its own scripts/ dir. --connect-timeout so a dead socket
-# fails fast enough for the retries to fit inside the step.
-retry_curl() {
-  local n=1
-  while (( n <= 3 )); do
-    if curl -fsSL --connect-timeout 20 "$@"; then
-      return 0
+GL_API="https://gitlab.alpinelinux.org/api/v4/projects/alpine%2Faports"
+GL_LIST="$GL_API/repository/tree?path=community/chromium&ref=$REF&per_page=100"
+GL_RAW="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/chromium"
+
+GH_LIST="https://api.github.com/repos/alpinelinux/aports/contents/community/chromium?ref=$REF"
+GH_RAW="https://raw.githubusercontent.com/alpinelinux/aports/$REF/community/chromium"
+
+# Overridable so the fallback can be EXERCISED rather than assumed — a fallback
+# that has never executed is not a fallback. tests/fetch-aports-fallback.sh
+# points the primary at an unroutable host and asserts the github leg returns
+# byte-identical files.
+GL_LIST="${APORTS_GL_LIST_OVERRIDE:-$GL_LIST}"
+GL_RAW="${APORTS_GL_RAW_OVERRIDE:-$GL_RAW}"
+# The mirror is overridable too, so the test can blackhole BOTH hosts and prove
+# the failure path still fails. A failover case that cannot be shown to fail
+# when it should is not evidence that it succeeded for the right reason.
+GH_LIST="${APORTS_GH_LIST_OVERRIDE:-$GH_LIST}"
+GH_RAW="${APORTS_GH_RAW_OVERRIDE:-$GH_RAW}"
+
+# Try both hosts, then back off and try both again. `what` is only for the
+# message, so a failure says which artifact AND which host, not just a URL.
+fetch_both_hosts() {
+  local what="$1" primary="$2" fallback="$3"
+  shift 3
+  local n=1 url host backoff
+  while (( n <= ATTEMPTS )); do
+    for host in gitlab github; do
+      if [[ "$host" == gitlab ]]; then
+        url="$primary"
+      else
+        url="$fallback"
+      fi
+      if curl -fsSL --connect-timeout "$CONNECT_TIMEOUT" --max-time "$MAX_TIME" \
+              "$url" "$@"; then
+        # Say so whenever the primary did NOT serve it, not only after a sleep:
+        # a build quietly running entirely off the mirror is worth seeing in the
+        # log before the mirror is the one that breaks.
+        if (( n > 1 )) || [[ "$host" == github ]]; then
+          echo "  recovered: $what from $host on round $n" >&2
+        fi
+        return 0
+      fi
+      echo "  NETWORK: $what unreachable at $host (round $n/$ATTEMPTS)" >&2
+    done
+    if (( n < ATTEMPTS )); then
+      backoff=$(( n * 5 < 30 ? n * 5 : 30 ))
+      echo "  NETWORK: both hosts failed, sleeping ${backoff}s" >&2
+      sleep "$backoff"
     fi
-    echo "  retry $n/3 (gitlab unreachable?) — sleep $((n*5))s" >&2
-    sleep $((n*5))
     n=$((n+1))
   done
+  echo "fetch-aports: NETWORK FAILURE — $what unreachable at BOTH" >&2
+  echo "  gitlab.alpinelinux.org and github.com after $ATTEMPTS rounds." >&2
+  echo "  This is an upstream/network fault, NOT the build scripts. BuildKit" >&2
+  echo "  will attribute it to the Dockerfile RUN line; ignore that." >&2
   return 1
 }
 
-files=$(retry_curl "$LIST_URL" | jq -r '.[] | select(.type=="blob") | .name')
+# GitLab calls them "blob", GitHub calls them "file" — accept either so one
+# listing parser serves both hosts.
+fetch_both_hosts "file listing" "$GL_LIST" "$GH_LIST" -o "$OUT/.listing.json"
+files=$(jq -r '.[] | select(.type=="blob" or .type=="file") | .name' "$OUT/.listing.json")
+rm -f "$OUT/.listing.json"
 
-[[ -z "$files" ]] && { echo "fetch-aports: no files at ref=$REF (gitlab API empty)" >&2; exit 1; }
+if [[ -z "$files" ]]; then
+  echo "fetch-aports: no files at ref=$REF (listing empty — wrong ref?)" >&2
+  exit 1
+fi
 
 for f in $files; do
-  raw="https://gitlab.alpinelinux.org/alpine/aports/-/raw/$REF/community/chromium/$f"
   echo "  fetch $f"
-  retry_curl "$raw" -o "$OUT/$f"
+  fetch_both_hosts "$f" "$GL_RAW/$f" "$GH_RAW/$f" -o "$OUT/$f"
 done
 
 echo "aports community/chromium fetched to $OUT ($(ls -1 "$OUT" | wc -l) files)"

--- a/playwright/alpine-browsers/chromium-headless-shell/tests/fetch-aports-fallback.sh
+++ b/playwright/alpine-browsers/chromium-headless-shell/tests/fetch-aports-fallback.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Exercise BOTH legs of fetch-aports.sh, because a fallback that has never
+# executed is not a fallback — it is a comment.
+#
+# Three cases, and the third is what makes the other two mean anything:
+#
+#   1. normal    both hosts up; gitlab serves. Establishes the reference bytes.
+#   2. failover  gitlab blackholed; github must serve BYTE-IDENTICAL files.
+#                This is the case that fires in the outage being defended
+#                against.
+#   3. both down both hosts blackholed; the script MUST fail. Without it, case 2
+#                could be passing for the wrong reason — e.g. if the fetch were
+#                silently writing nothing and returning 0, cases 1 and 2 would
+#                both "pass" and diff clean against each other.
+#
+# 192.0.2.1 is TEST-NET-1 (RFC 5737), a routable-looking address that goes
+# nowhere. Deliberately not a bogus hostname: DNS failure and connection failure
+# are different code paths in curl, and a blackholed address is the closer
+# analogue of the real outage.
+#
+# usage: ALPINE_APORTS_CHROMIUM_REF=<sha> tests/fetch-aports-fallback.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FETCH="$HERE/../scripts/fetch-aports.sh"
+: "${ALPINE_APORTS_CHROMIUM_REF:?set it, e.g. from playwright/alpine-browsers/versions.env}"
+export ALPINE_APORTS_CHROMIUM_REF
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+# One round, 3 s connect: the point is to prove which host answered, not to sit
+# through the six-minute production budget.
+export APORTS_ATTEMPTS=1 APORTS_CONNECT_TIMEOUT=3
+DEAD_LIST="https://192.0.2.1/list"
+DEAD_RAW="https://192.0.2.1/raw"
+
+echo "=== 1. normal: both hosts reachable"
+if bash "$FETCH" "$TMP/normal" > "$TMP/normal.log" 2>&1; then
+  echo "    ok — $(ls -1 "$TMP/normal" | wc -l) files"
+else
+  echo "    FAILED (is the network up?)"
+  cat "$TMP/normal.log"
+  fail=1
+fi
+
+echo "=== 2. failover: gitlab blackholed, github must serve identical bytes"
+if APORTS_GL_LIST_OVERRIDE="$DEAD_LIST" APORTS_GL_RAW_OVERRIDE="$DEAD_RAW" \
+   bash "$FETCH" "$TMP/failover" > "$TMP/failover.log" 2>&1; then
+  echo "    ok — $(ls -1 "$TMP/failover" | wc -l) files"
+else
+  echo "    FAILED — the github leg did not serve"
+  cat "$TMP/failover.log"
+  fail=1
+fi
+# It must have actually gone to the mirror, not quietly succeeded on gitlab.
+if ! grep -q "from github" "$TMP/failover.log" 2>/dev/null; then
+  echo "    VACUOUS — nothing in the log says github served it"
+  fail=1
+fi
+
+if [[ -d "$TMP/normal" && -d "$TMP/failover" ]]; then
+  if diff -r "$TMP/normal" "$TMP/failover" > "$TMP/diff.log" 2>&1; then
+    echo "    bytes identical across hosts"
+  else
+    echo "    MISMATCH — the mirror is not a mirror:"
+    cat "$TMP/diff.log"
+    fail=1
+  fi
+  # Two empty trees diff clean and prove nothing.
+  n=$(ls -1 "$TMP/failover" | wc -l)
+  if [[ "$n" -lt 5 ]]; then
+    echo "    VACUOUS — only $n files; the comparison checked nothing"
+    fail=1
+  fi
+  if [[ ! -s "$TMP/failover/APKBUILD" ]]; then
+    echo "    VACUOUS — no APKBUILD in the failover tree"
+    fail=1
+  fi
+fi
+
+echo "=== 3. both hosts blackholed: must FAIL"
+if APORTS_GL_LIST_OVERRIDE="$DEAD_LIST" APORTS_GL_RAW_OVERRIDE="$DEAD_RAW" \
+   APORTS_GH_LIST_OVERRIDE="$DEAD_LIST" APORTS_GH_RAW_OVERRIDE="$DEAD_RAW" \
+   bash "$FETCH" "$TMP/dead" > "$TMP/dead.log" 2>&1; then
+  echo "    FAILED — it reported success with both hosts unreachable"
+  fail=1
+else
+  echo "    ok — failed as required"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "FAIL"
+  exit 1
+fi
+echo "PASS"


### PR DESCRIPTION
Ports firefox's #144 to chromium, which has the identical exposure and a worse blast radius: `fetch-aports.sh` runs at the head of a chain whose cold path is 25-30 h, so a 75-second gitlab outage at minute one costs a day. The old budget was 3 tries / ~75 s against a single host — nothing against an outage lasting minutes.

Two levers, both cheap next to a 25 h compile: a wider budget (5 rounds, 30 s connect, 5/10/20/30 s backoff, ~6 min worst case) and a **second host**.

## I re-verified the mirror rather than inheriting the check

firefox verified github.com/alpinelinux/aports at `66e79518` for `community/firefox`. That says nothing about a different package at a different sha, so I checked ours: at **`124cc885`**, gitlab and github return the **same 25-file listing** and a **byte-identical APKBUILD**, md5 `ea152f1882c767aed832842caf3286e0` from both.

## The fallback is exercised, not asserted

`tests/fetch-aports-fallback.sh`, run locally against the real hosts:

```
=== 1. normal: both hosts reachable
    ok — 25 files
=== 2. failover: gitlab blackholed, github must serve identical bytes
    ok — 25 files
    bytes identical across hosts
=== 3. both hosts blackholed: must FAIL
    ok — failed as required
PASS
```

**Case 3 is what makes case 2 mean anything.** Without it, a fetch that silently wrote nothing and returned 0 would pass cases 1 and 2 and diff clean against itself. Case 2 additionally greps the log for `from github`, so it cannot pass by quietly succeeding on the primary, and it rejects a tree with fewer than 5 files or no `APKBUILD`.

192.0.2.1 (TEST-NET-1, RFC 5737) rather than a hostname that does not resolve — DNS failure and connection failure are different code paths in curl, and a blackholed address is the closer analogue of the real outage. Both hosts and the retry budget are overridable purely so the test can drive them in seconds instead of six minutes.

## Two smaller things

- The fetcher now logs `recovered: <file> from github` whenever the primary did **not** serve, not only after a sleep. A build running entirely off the mirror is worth seeing in the log *before* the mirror is the one that breaks.
- Wired into `tests-aports.yml`, and `fetch-aports.sh` + the test added to its **path filter** — otherwise the gate would not run when the thing it guards changes. It talks to the real network on purpose: the claim under test is that the mirror still mirrors, and mocking it would assert nothing.

## Note on the chains already in flight

This does not retroactively protect **33084475914** (main-lineage, past setup) or **33119557452** (SSP parity, cold). Both still run the old single-host fetcher from their own refs. If either dies at `fetch-aports`, that is the failure this PR prevents on the re-dispatch, and BuildKit will misattribute it to whichever `RUN` line the branch touched — which is exactly why every message in the new version names the network explicitly.

Assisted-by: Claude:claude-opus-5[1m]